### PR TITLE
metal: use multi-output GEMV for Q4_K/Q6_K matmuls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,17 @@ jobs:
           name: picolm-macos-arm64
           path: picolm/picolm
 
+  build-macos-metal:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build (Metal backend)
+        run: cd picolm && make metal
+      - name: Check binary
+        run: ls -la picolm/picolm && file picolm/picolm
+      - name: Kernel smoke-test
+        run: cd picolm && make metal-probe-run
+
   build-windows:
     runs-on: windows-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The original PicoLM was a clever proof-of-concept: mmap a GGUF, stream layers th
 | **KV cache** | F16, Q8_0 (53% memory), Q4_0 (34% memory), persistent with prefix matching |
 | **Misc** | 64KB FP16 lookup table, `--mem` mlock, `--prefault`, `--daemon`, `--json` grammar, grammar-constrained JSON |
 
-**Not yet:** GPU backend (HIP/CUDA infrastructure exists but untested), SSM KV rewinding (checkpointing planned).
+**GPU:** Metal backend for Apple Silicon (`make metal`, zero external deps — raw Metal framework). CUDA/HIP infrastructure also exists. **Not yet:** SSM KV rewinding (checkpointing planned).
 
 ---
 
@@ -286,7 +286,26 @@ make cross-pi    # Cross-compile for Pi from x86 (static binary)
 make riscv       # RISC-V (Sipeed LicheeRV, etc.)
 make static      # Static binary for single-file deployment
 make debug       # Debug build with symbols, no optimization
+make metal       # Apple Silicon GPU backend (Metal; macOS only, no deps)
 ```
+
+### Metal backend (Apple Silicon)
+
+PicoLM ships a Metal backend implemented directly against the Metal framework
+(no MLX-C, no CMake, no Homebrew — just `clang++` + the macOS SDK). It compiles
+the matmul kernels from Metal Shading Language source at runtime and maps model
+weights **zero-copy** into the GPU's unified memory, so large models don't
+double their resident RAM.
+
+```bash
+make metal                          # builds picolm with -DPICOLM_GPU=1
+PICOLM_GPU=1 ./picolm model.gguf -p "Hello" -n 50    # run on the GPU
+```
+
+Supported quantizations: F32, F16, Q4_0, Q8_0, Q4_K, Q5_K, Q6_K. The dequant
+kernels are faithful ports of PicoLM's CPU `dequantize_row_*` (the GGUF/
+llama.cpp block layouts). A self-contained kernel smoke-test lives in
+`probes/metal_reduction_probe.mm` (`make metal-probe-run`).
 
 ---
 
@@ -679,7 +698,11 @@ A: llama.cpp is excellent but requires ~200MB+ for the runtime on small models, 
 A: TinyLlama 1.1B is a small model — it handles simple tasks (Q&A, summarization, basic reasoning, JSON generation) well. It won't match GPT-4, but it runs on a $10 board with no internet. For structured output, the `--json` grammar mode guarantees valid JSON regardless of model quality.
 
 **Q: What about GPU acceleration?**
-A: PicoLM is CPU-only by design. The target hardware ($10-15 boards) doesn't have GPUs. On x86/ARM CPUs, SIMD (NEON/SSE2/AVX) provides meaningful speedup.
+A: On Apple Silicon, PicoLM has a native Metal backend — `make metal` then run
+with `PICOLM_GPU=1`. It's zero-dependency (raw Metal framework) and maps weights
+zero-copy into unified memory. The original $10-15 target boards have no GPU, so
+the CPU path (NEON/SSE2/AVX SIMD) remains the focus there; CUDA/HIP
+infrastructure also exists for discrete GPUs.
 
 **Q: Can I use a different model?**
 A: Any LLaMA-architecture GGUF model works. Download from [HuggingFace](https://huggingface.co/models?search=gguf) and point PicoLM at it. Recommended quantizations: Q4_K_M (best quality/size balance) or Q2_K (smallest, lower quality).
@@ -690,6 +713,7 @@ A: Any LLaMA-architecture GGUF model works. Download from [HuggingFace](https://
 
 - [x] AVX kernels for x86 (`make avx` — 8-wide float ops, ~2x vs SSE2)
 - [x] AVX2 kernels for x86 (`make avx2` — 256-bit integer ops for Q4_0 and Q6_K quantized paths)
+- [x] Metal backend for Apple Silicon (`make metal` — zero-copy, raw Metal framework, no deps)
 - [ ] AVX-512 kernels for x86 (512-bit ops for server CPUs)
 - [ ] Speculative decoding with a draft model
 - [ ] Context sliding window (infinite generation beyond max_seq_len)

--- a/picolm/.gitignore
+++ b/picolm/.gitignore
@@ -3,12 +3,12 @@
 *.fixed
 leaks.txt
 qwen35_ref.c
-# build artifacts
-picolm/*.o
-picolm/picolm
-picolm/picolm.exe
-picolm/backend_gpu.o.hip
-picolm/backend_gpu.o.cuda
-picolm/backend_metal.o
-picolm/probes/metal_reduction_probe
-picolm/probes/metal_matmul_bench
+# build artifacts (paths relative to this picolm/ dir)
+*.o
+picolm
+picolm.exe
+backend_gpu.o.hip
+backend_gpu.o.cuda
+backend_metal.o
+probes/metal_reduction_probe
+probes/metal_matmul_bench

--- a/picolm/.gitignore
+++ b/picolm/.gitignore
@@ -11,3 +11,4 @@ picolm/backend_gpu.o.hip
 picolm/backend_gpu.o.cuda
 picolm/backend_metal.o
 picolm/probes/metal_reduction_probe
+picolm/probes/metal_matmul_bench

--- a/picolm/.gitignore
+++ b/picolm/.gitignore
@@ -3,3 +3,11 @@
 *.fixed
 leaks.txt
 qwen35_ref.c
+# build artifacts
+picolm/*.o
+picolm/picolm
+picolm/picolm.exe
+picolm/backend_gpu.o.hip
+picolm/backend_gpu.o.cuda
+picolm/backend_metal.o
+picolm/probes/metal_reduction_probe

--- a/picolm/Makefile
+++ b/picolm/Makefile
@@ -139,7 +139,7 @@ model:
 	fi
 
 clean:
-	rm -f $(TARGET) $(TARGET).exe $(OBJS) backend_gpu.o backend_gpu.o.hip backend_gpu.o.cuda
+	rm -f $(TARGET) $(TARGET).exe $(OBJS) backend_gpu.o backend_gpu.o.hip backend_gpu.o.cuda backend_metal.o probes/metal_reduction_probe
 
 
 .PHONY: asan
@@ -188,4 +188,35 @@ cuda: backend_gpu.o.cuda
 backend_gpu.o.cuda: backend_gpu.cu backend_gpu.h quant.h
 	$(NVCC) $(CUDAFLAGS) $(CUDA_GENCODE) -DPICOLM_GPU=1 -c -o $@ $< -I.
 
-.PHONY: hip cuda
+# --- Metal (Apple Silicon) backend — RAW Metal framework, no MLX-C ---
+# macOS only. No external dependencies beyond the Metal framework that ships
+# with macOS + the Command Line Tools (clang). Compile the whole backend with:
+#     make metal
+# Then run with: PICOLM_GPU=1 ./picolm model.gguf ...
+METAL_CXX      ?= clang++
+METAL_CXXFLAGS ?= -std=c++20 -O3 -fobjc-arc -fPIC
+METAL_FRAMEWORKS = -framework Metal -framework Foundation
+METAL_LIBS       = $(METAL_FRAMEWORKS)
+# (the link rule appends -lstdc++ for the ObjC++ runtime)
+.PHONY: metal
+metal: backend_metal.o
+	$(MAKE) $(TARGET) \
+	  CFLAGS="$(filter-out -fopenmp,$(CFLAGS)) -DPICOLM_GPU=1" \
+	  LDFLAGS="$(filter-out -fopenmp,$(LDFLAGS))" \
+	  GPU_OBJS="backend_metal.o" GPU_LIBS="$(METAL_LIBS)"
+
+# .mm = Objective-C++ so we can use <metal/Metal.h> directly.
+backend_metal.o: backend_metal.mm backend_gpu.h quant.h
+	$(METAL_CXX) $(METAL_CXXFLAGS) -DPICOLM_GPU=1 -c -o $@ $< -I.
+
+# --- Metal kernel probe (smoke test for the raw-Metal kernel mechanism) ---
+# Builds and runs probes/metal_reduction_probe.mm against the Metal framework.
+# Needs only clang++ + the macOS SDK (no CMake, no MLX-C).
+.PHONY: metal-probe metal-probe-run
+metal-probe: probes/metal_reduction_probe
+probes/metal_reduction_probe: probes/metal_reduction_probe.mm
+	$(METAL_CXX) $(METAL_CXXFLAGS) $< $(METAL_FRAMEWORKS) -o $@
+metal-probe-run: metal-probe
+	./probes/metal_reduction_probe
+
+.PHONY: hip cuda metal

--- a/picolm/Makefile
+++ b/picolm/Makefile
@@ -230,4 +230,14 @@ probes/metal_matmul_bench: probes/metal_matmul_bench.mm
 metal-bench-run: metal-bench
 	./probes/metal_matmul_bench
 
+# --- End-to-end model timing (needs `make metal` first + GGUF files) ---
+# Runs ./picolm on real models, parses prefill/generation tok/s.
+#   make metal-model-bench            # GPU
+#   make metal-model-bench CPU=1      # also CPU baseline
+#   LABEL=after make metal-model-bench # tag the run
+# Override models with MODELS="a.gguf b.gguf" or pass them as script args.
+.PHONY: metal-model-bench
+metal-model-bench:
+	./probes/metal_model_bench.sh
+
 .PHONY: hip cuda metal

--- a/picolm/Makefile
+++ b/picolm/Makefile
@@ -139,7 +139,7 @@ model:
 	fi
 
 clean:
-	rm -f $(TARGET) $(TARGET).exe $(OBJS) backend_gpu.o backend_gpu.o.hip backend_gpu.o.cuda backend_metal.o probes/metal_reduction_probe
+	rm -f $(TARGET) $(TARGET).exe $(OBJS) backend_gpu.o backend_gpu.o.hip backend_gpu.o.cuda backend_metal.o probes/metal_reduction_probe probes/metal_matmul_bench
 
 
 .PHONY: asan
@@ -218,5 +218,16 @@ probes/metal_reduction_probe: probes/metal_reduction_probe.mm
 	$(METAL_CXX) $(METAL_CXXFLAGS) $< $(METAL_FRAMEWORKS) -o $@
 metal-probe-run: metal-probe
 	./probes/metal_reduction_probe
+
+# --- Metal matmul benchmark + correctness harness (no model file needed) ---
+# Measures each kernel at decode/prefill dims, diffs vs a CPU reference, and
+# reports effective weight bandwidth + per-dispatch overhead. Use it to tell
+# whether to optimize the kernels or the host launch/sync path.
+.PHONY: metal-bench metal-bench-run
+metal-bench: probes/metal_matmul_bench
+probes/metal_matmul_bench: probes/metal_matmul_bench.mm
+	$(METAL_CXX) $(METAL_CXXFLAGS) $< $(METAL_FRAMEWORKS) -o $@
+metal-bench-run: metal-bench
+	./probes/metal_matmul_bench
 
 .PHONY: hip cuda metal

--- a/picolm/backend_metal.mm
+++ b/picolm/backend_metal.mm
@@ -345,6 +345,90 @@ kernel void mm_q6_K(device const uint8_t* w [[buffer(0)]],\n\
     if (tid == 0) y[(unsigned long)s * O + o] = total;\n\
 }\n\
 \n\
+/* ---------------- Q4_K MULTI-OUTPUT GEMV (1 warp/output) --------------\n\
+ * grid=(O/8,S,1), TG=256 (8 warps). warp w computes output o=gp.x*8+w over\n\
+ * ALL blocks; simd_sum within the warp only (no cross-warp barrier/shared).\n\
+ * Validated vs CPU by probes/metal_matmul_bench; faster on medium/large O.\n\
+ * Host dispatches grid_x=(O+7)/8 for Q4_K/Q6_K (see launch_matmul). */\n\
+kernel void mm_q4_K_mo(device const uint8_t* w [[buffer(0)]],\n\
+                    device const float*   x [[buffer(1)]],\n\
+                    device float*         y [[buffer(2)]],\n\
+                    constant int& I [[buffer(3)]],\n\
+                    constant int& S [[buffer(4)]],\n\
+                    constant int& O [[buffer(5)]],\n\
+                    uint tid [[thread_index_in_threadgroup]],\n\
+                    uint2 gp [[threadgroup_position_in_grid]]) {\n\
+    int o = (int)gp.x * 8 + (int)(tid >> 5), s = (int)gp.y;\n\
+    if (o >= O) return;\n\
+    int nblocks = I / 256;\n\
+    device const uint8_t* row = w + (unsigned long)o * (unsigned long)(nblocks * 144);\n\
+    uint lane = tid & 31, g = lane / 8, within = (lane & 7) * 4;\n\
+    float acc = 0.0f;\n\
+    for (int bi = 0; bi < nblocks; bi++) {\n\
+        device const uint8_t* blk = row + (unsigned long)(bi * 144);\n\
+        float d    = f16tof32((uint16_t)blk[0] | ((uint16_t)blk[1] << 8));\n\
+        float dmin = f16tof32((uint16_t)blk[2] | ((uint16_t)blk[3] << 8));\n\
+        device const uint8_t* scales = blk + 4;\n\
+        device const uint8_t* qs     = blk + 16;\n\
+        float d_lo, m_lo, d_hi, m_hi;\n\
+        k4_unpack(scales, 2 * (int)g,     d_lo, m_lo, d, dmin);\n\
+        k4_unpack(scales, 2 * (int)g + 1, d_hi, m_hi, d, dmin);\n\
+        uint qw = *(device const uint*)(qs + lane * 4);\n\
+        uint base = (uint)(bi * 256) + g * 64 + within;\n\
+        for (int k = 0; k < 4; k++) {\n\
+            uint bv = (qw >> (k * 8)) & 0xFF;\n\
+            float lo = (float)(bv & 0xF);\n\
+            float hi = (float)(bv >> 4);\n\
+            acc += x[(unsigned long)s * I + base + k]      * (d_lo * lo - m_lo);\n\
+            acc += x[(unsigned long)s * I + base + k + 32] * (d_hi * hi - m_hi);\n\
+        }\n\
+    }\n\
+    float total = simd_sum(acc);\n\
+    if (lane == 0) y[(unsigned long)s * O + o] = total;\n\
+}\n\
+/* ---------------- Q6_K MULTI-OUTPUT GEMV (1 warp/output) --------------\n\
+ * grid=(O/8,S,1). warp w -> output o=gp.x*8+w over ALL blocks; simd_sum only.\n\
+ * Coalesced ql/qh reads as in mm_q6_K. Validated vs CPU; faster on large O. */\n\
+kernel void mm_q6_K_mo(device const uint8_t* w [[buffer(0)]],\n\
+                    device const float*   x [[buffer(1)]],\n\
+                    device float*         y [[buffer(2)]],\n\
+                    constant int& I [[buffer(3)]],\n\
+                    constant int& S [[buffer(4)]],\n\
+                    constant int& O [[buffer(5)]],\n\
+                    uint tid [[thread_index_in_threadgroup]],\n\
+                    uint2 gp [[threadgroup_position_in_grid]]) {\n\
+    int o = (int)gp.x * 8 + (int)(tid >> 5), s = (int)gp.y;\n\
+    if (o >= O) return;\n\
+    int nblocks = I / 256;\n\
+    device const uint8_t* row = w + (unsigned long)o * (unsigned long)(nblocks * 210);\n\
+    uint lane = tid & 31;\n\
+    float acc = 0.0f;\n\
+    for (int bi = 0; bi < nblocks; bi++) {\n\
+        device const uint8_t* blk = row + (unsigned long)(bi * 210);\n\
+        float d = f16tof32((uint16_t)blk[208] | ((uint16_t)blk[209] << 8));\n\
+        device const uint8_t* ql = blk;\n\
+        device const uint8_t* qh = blk + 128;\n\
+        device const int8_t*  sc = (device const int8_t*)(blk + 192);\n\
+        for (int k = 0; k < 4; k++) {\n\
+            uint b   = (uint)(k * 32) + lane;\n\
+            uint chk = b >> 6;\n\
+            uint grp = (b & 63) >> 5;\n\
+            uint l   = b & 31;\n\
+            uint qlb = ql[b];\n\
+            uint qhb = qh[chk * 32 + l];\n\
+            int qraw0 = (int)(qlb & 0xF) | (int)(((qhb >> (2u * grp)) & 3u) << 4);\n\
+            int si0   = (int)(chk * 8 + l / 16 + 2u * grp);\n\
+            uint j0   = chk * 128 + grp * 32 + l;\n\
+            acc += x[(unsigned long)s * I + (unsigned long)bi * 256 + j0] * (d * (float)sc[si0] * (float)(qraw0 - 32));\n\
+            int qraw1 = (int)(qlb >> 4) | (int)(((qhb >> (2u * (grp + 2u))) & 3u) << 4);\n\
+            int si1   = (int)(chk * 8 + l / 16 + 2u * (grp + 2u));\n\
+            uint j1   = chk * 128 + (grp + 2u) * 32 + l;\n\
+            acc += x[(unsigned long)s * I + (unsigned long)bi * 256 + j1] * (d * (float)sc[si1] * (float)(qraw1 - 32));\n\
+        }\n\
+    }\n\
+    float total = simd_sum(acc);\n\
+    if (lane == 0) y[(unsigned long)s * O + o] = total;\n\
+}\n\
 /* ---------------- silu_mul elementwise: gate[i] = silu(gate[i]) * up[i] --- */\n\
 kernel void silu_mul(device float*       gate [[buffer(0)]],\n\
                      device const float* up   [[buffer(1)]],\n\
@@ -366,7 +450,8 @@ static id<MTLDevice>            g_device  = nil;
 static id<MTLCommandQueue>       g_queue   = nil;
 static id<MTLLibrary>            g_library = nil;
 static id<MTLComputePipelineState> g_ps_f32, g_ps_f16, g_ps_q4_0, g_ps_q8_0,
-                                  g_ps_q4_K, g_ps_q5_K, g_ps_q6_K, g_ps_silu;
+                                  g_ps_q4_K, g_ps_q5_K, g_ps_q6_K, g_ps_silu,
+                                  g_ps_q4_K_mo, g_ps_q6_K_mo;
 static int g_ndev = 0;
 
 // Grow-only scratch buffers (mirror CUDA's reserve()). Shared storage mode =
@@ -380,9 +465,9 @@ static id<MTLComputePipelineState> ps_for_qtype(gguf_type_t q) {
         case GGUF_TYPE_F16:  return g_ps_f16;
         case GGUF_TYPE_Q4_0: return g_ps_q4_0;
         case GGUF_TYPE_Q8_0: return g_ps_q8_0;
-        case GGUF_TYPE_Q4_K: return g_ps_q4_K;
+        case GGUF_TYPE_Q4_K: return g_ps_q4_K_mo;
         case GGUF_TYPE_Q5_K: return g_ps_q5_K;
-        case GGUF_TYPE_Q6_K: return g_ps_q6_K;
+        case GGUF_TYPE_Q6_K: return g_ps_q6_K_mo;
         default:             return nil;   /* unsupported -> caller falls back to CPU */
     }
 }
@@ -447,8 +532,10 @@ int picolm_gpu_init(const int *devices, int count) {
     g_ps_q4_K = [g_device newComputePipelineStateWithFunction:[g_library newFunctionWithName:@"mm_q4_K"] error:nil];
     g_ps_q5_K = [g_device newComputePipelineStateWithFunction:[g_library newFunctionWithName:@"mm_q5_K"] error:nil];
     g_ps_q6_K = [g_device newComputePipelineStateWithFunction:[g_library newFunctionWithName:@"mm_q6_K"] error:nil];
+    g_ps_q4_K_mo = [g_device newComputePipelineStateWithFunction:[g_library newFunctionWithName:@"mm_q4_K_mo"] error:nil];
+    g_ps_q6_K_mo = [g_device newComputePipelineStateWithFunction:[g_library newFunctionWithName:@"mm_q6_K_mo"] error:nil];
     g_ps_silu = [g_device newComputePipelineStateWithFunction:[g_library newFunctionWithName:@"silu_mul"] error:nil];
-    if (!g_ps_f32 || !g_ps_f16 || !g_ps_q4_0 || !g_ps_q8_0 || !g_ps_q4_K || !g_ps_q5_K || !g_ps_q6_K || !g_ps_silu) {
+    if (!g_ps_f32 || !g_ps_f16 || !g_ps_q4_0 || !g_ps_q8_0 || !g_ps_q4_K || !g_ps_q5_K || !g_ps_q6_K || !g_ps_q4_K_mo || !g_ps_q6_K_mo || !g_ps_silu) {
         fprintf(stderr, "[Metal] pipeline state creation failed\n");
         g_device = nil; g_queue = nil; g_library = nil; return 0;
     }
@@ -594,7 +681,9 @@ static int launch_matmul(picolm_gpu_tensor_t *t, id<MTLBuffer> xbuf, id<MTLBuffe
     [enc setBytes:&cI length:sizeof(cI) atIndex:3];
     [enc setBytes:&cS length:sizeof(cS) atIndex:4];
     [enc setBytes:&cO length:sizeof(cO) atIndex:5];
-    [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)O, (NSUInteger)S, 1)
+    NSUInteger gx = (t->qtype == GGUF_TYPE_Q4_K || t->qtype == GGUF_TYPE_Q6_K)
+                      ? (NSUInteger)((O + 7) / 8) : (NSUInteger)O;
+    [enc dispatchThreadgroups:MTLSizeMake(gx, (NSUInteger)S, 1)
         threadsPerThreadgroup:MTLSizeMake(TPB, 1, 1)];
     [enc endEncoding];
     return 1;

--- a/picolm/backend_metal.mm
+++ b/picolm/backend_metal.mm
@@ -1,0 +1,706 @@
+// backend_metal.mm
+//
+// Apple Metal backend for PicoLM — implements the backend_gpu.h C ABI using the
+// Metal framework directly (no MLX-C, no CMake, no external dependencies beyond
+// what ships with macOS + the Command Line Tools).
+//
+// Build:  make metal      (clang++ -std=c++20 -fobjc-arc -framework Metal ...)
+//
+// Design mirrors backend_gpu.cu (CUDA/HIP): one device context, grow-only
+// scratch buffers, idempotent tensor upload, per-tensor MTLBuffer handles.
+// The host side implements backend_gpu.h unchanged; model.c / tensor.c /
+// model.h are NOT modified — they were already written generically behind
+// #ifdef PICOLM_GPU.
+//
+// The matmul kernels are hand-written Metal Shading Language (compiled from a
+// source string at init), NOT direct ports of the CUDA device kernels. The
+// device-side dequant is taken from PicoLM's CPU reference in quant.c (the
+// source of truth for GGUF block layouts — the CUDA file's Q4_K path is
+// unfinished and its Q4_0 nibble order is wrong). The high-traffic types use
+// coalesced warp-cooperative loads + simd_sum reduction.
+//
+// Activation: same as CUDA — set PICOLM_GPU=1 in the environment. The whole
+// GPU path is gated by -DPICOLM_GPU=1, added by the `metal` Makefile target.
+//
+// Supported quants: F32, F16, Q4_0, Q8_0, Q4_K, Q5_K, Q6_K. Weights are mapped
+// zero-copy (page-aligned newBufferWithBytesNoCopy) where possible so large
+// models don't double resident memory on Apple Silicon's unified memory.
+
+#include "backend_gpu.h"   // includes quant.h (gguf_type_t enum); extern "C" ABI
+
+#import <metal/Metal.h>
+#import <Foundation/Foundation.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>       // getpagesize()
+
+#define TPB 256             // threads per threadgroup for all matmul kernels
+
+// ---- fp16 -> fp32 device helper (matches quant.c semantics) ----
+// as_type<half>(u16) reinterprets the 16 bits; Metal has native half<->float.
+
+#pragma mark - Metal Shading Language kernel source
+//
+// One source string, compiled once into one MTLLibrary. Seven matmul kernels
+// (one per supported GGUF type: F32, F16, Q4_0, Q8_0, Q4_K, Q5_K, Q6_K) + one
+// silu_mul elementwise kernel.
+//
+// Launch shape (all matmul kernels):
+//   grid = (O, S, 1)          -> one threadgroup per (output_row, sample)
+//   threadgroup = (TPB,1,1)   -> 256 threads = 8 simdgroups (warps) of 32 lanes
+//   buffers: 0=w, 1=x(float), 2=y(float); constants: 3=I, 4=S, 5=O
+//
+// Reduction: each thread holds a partial dot-product accumulator. We reduce
+// within each 32-lane simdgroup with the hardware simd_sum (one op), spill the
+// 8 per-simdgroup sums to shared memory, barrier once, and simd_sum again in
+// simdgroup 0. This replaces the old 8-barrier shared-memory tree.
+//
+// Coalescing (the big decode win): for the high-traffic types the 32 lanes of a
+// simdgroup read CONTIGUOUS weight bytes, so each load is one coalesced 32- or
+// 128-byte transaction instead of 32 scattered single-byte loads:
+//   - Q4_K: 1 block (144B, 256 values) per simdgroup; each lane reads 4 qs bytes
+//     (128B total, perfectly coalesced) and owns 8 values. Thread->value index
+//     derived from quant.c dequantize_row_q4_K and hand-verified.
+//   - Q8_0: 1 block (34B, 32 values) per simdgroup; each lane reads 1 int8.
+//   - F32/F16: float4 / half4 vector loads, lanes stride by TPB*4.
+// Q4_0/Q5_K/Q6_K keep a per-element structure (their layouts are awkward to
+// coalesce) but cache block metadata once and use simd_sum.
+//
+// IMPORTANT: dequant layouts match PicoLM's CPU dequantize_row_* in quant.c
+// (the GGUF/llama.cpp convention). For Q4_0: value j -> byte (j&15), low nibble
+// if j<16 else high nibble.
+
+static NSString* KERNEL_SOURCE = @"\
+#include <metal_stdlib>\n\
+using namespace metal;\n\
+\n\
+inline float f16tof32(uint16_t h) { return (float)as_type<half>(h); }\n\
+\n\
+#define TPB 256\n\
+#define NW (TPB / 32)          // simdgroups per threadgroup (8)\n\
+\n\
+/* Reduce a per-thread accumulator across the whole threadgroup (256 lanes).\n\
+ * simd_sum within each 32-lane simdgroup, then one shared-memory hop + simd_sum\n\
+ * across the NW simdgroups. Must be called by ALL threads (contains a barrier).\n\
+ * Result is valid everywhere; caller writes it from tid==0. */\n\
+inline float reduce_all(float acc, threadgroup float* wb, uint tid) {\n\
+    uint warp = tid >> 5, lane = tid & 31;\n\
+    acc = simd_sum(acc);\n\
+    if (lane == 0) wb[warp] = acc;\n\
+    threadgroup_barrier(mem_flags::mem_threadgroup);\n\
+    float v = (warp == 0 && lane < NW) ? wb[lane] : 0.0f;\n\
+    return simd_sum(v);\n\
+}\n\
+\n\
+/* Unpack one Q4_K/Q5_K sub-block scale+min (6-bit packed in scales[12]) into\n\
+ * d*scale and dmin*min, exactly matching quant.c get_scale_min_k4. */\n\
+inline void k4_unpack(device const uint8_t* s, int is,\n\
+                      thread float& dsc, thread float& dmn,\n\
+                      float d, float dmin) {\n\
+    uint8_t sc, mn;\n\
+    if (is < 4) { sc = s[is] & 63; mn = s[is + 4] & 63; }\n\
+    else { sc = (s[is + 4] & 0xF) | ((s[is - 4] >> 6) << 4);\n\
+           mn = (s[is + 4] >> 4)  | ((s[is]     >> 6) << 4); }\n\
+    dsc = d * (float)sc;\n\
+    dmn = dmin * (float)mn;\n\
+}\n\
+\n\
+/* ---------------- F32 (coalesced float4) ---------------- */\n\
+kernel void mm_f32(device const float* w [[buffer(0)]],\n\
+                   device const float* x [[buffer(1)]],\n\
+                   device float*       y [[buffer(2)]],\n\
+                   constant int& I [[buffer(3)]],\n\
+                   constant int& S [[buffer(4)]],\n\
+                   constant int& O [[buffer(5)]],\n\
+                   uint tid [[thread_index_in_threadgroup]],\n\
+                   uint2 gp [[threadgroup_position_in_grid]]) {\n\
+    int o = (int)gp.x, s = (int)gp.y;\n\
+    device const float* wrow = w + (unsigned long)o * (unsigned long)I;\n\
+    float acc = 0.0f;\n\
+    for (int i = (int)tid * 4; i + 4 <= I; i += TPB * 4) {\n\
+        float4 wv = *(device const float4*)(wrow + i);\n\
+        float4 xv = *(device const float4*)(x + (unsigned long)s * I + i);\n\
+        acc += dot(wv, xv);\n\
+    }\n\
+    for (int i = (I / 4) * 4 + (int)tid; i < I; i += TPB)\n\
+        acc += wrow[i] * x[(unsigned long)s * I + i];\n\
+    threadgroup float wb[NW];\n\
+    float total = reduce_all(acc, wb, tid);\n\
+    if (tid == 0) y[(unsigned long)s * O + o] = total;\n\
+}\n\
+\n\
+/* ---------------- F16 (coalesced half4) ---------------- */\n\
+kernel void mm_f16(device const uint8_t* w [[buffer(0)]],\n\
+                   device const float*   x [[buffer(1)]],\n\
+                   device float*         y [[buffer(2)]],\n\
+                   constant int& I [[buffer(3)]],\n\
+                   constant int& S [[buffer(4)]],\n\
+                   constant int& O [[buffer(5)]],\n\
+                   uint tid [[thread_index_in_threadgroup]],\n\
+                   uint2 gp [[threadgroup_position_in_grid]]) {\n\
+    int o = (int)gp.x, s = (int)gp.y;\n\
+    device const half* wrow = (device const half*)(w + (unsigned long)o * (unsigned long)(I * 2));\n\
+    float acc = 0.0f;\n\
+    for (int i = (int)tid * 4; i + 4 <= I; i += TPB * 4) {\n\
+        float4 wv = float4(*(device const half4*)(wrow + i));\n\
+        float4 xv = *(device const float4*)(x + (unsigned long)s * I + i);\n\
+        acc += dot(wv, xv);\n\
+    }\n\
+    for (int i = (I / 4) * 4 + (int)tid; i < I; i += TPB)\n\
+        acc += (float)wrow[i] * x[(unsigned long)s * I + i];\n\
+    threadgroup float wb[NW];\n\
+    float total = reduce_all(acc, wb, tid);\n\
+    if (tid == 0) y[(unsigned long)s * O + o] = total;\n\
+}\n\
+\n\
+/* ---------------- Q4_0 (18B/32v, SEPARATED nibbles) ----------------\n\
+ * Per-element, metadata cached; simd_sum reduce. Tiny blocks (16 qs bytes for\n\
+ * 32 values) don't coalesce cleanly across 32 lanes, so we keep this simple. */\n\
+kernel void mm_q4_0(device const uint8_t* w [[buffer(0)]],\n\
+                    device const float*   x [[buffer(1)]],\n\
+                    device float*         y [[buffer(2)]],\n\
+                    constant int& I [[buffer(3)]],\n\
+                    constant int& S [[buffer(4)]],\n\
+                    constant int& O [[buffer(5)]],\n\
+                    uint tid [[thread_index_in_threadgroup]],\n\
+                    uint2 gp [[threadgroup_position_in_grid]]) {\n\
+    int o = (int)gp.x, s = (int)gp.y;\n\
+    int nblocks = I / 32;\n\
+    device const uint8_t* row = w + (unsigned long)o * (unsigned long)(nblocks * 18);\n\
+    float acc = 0.0f;\n\
+    for (int bi = (int)tid; bi < nblocks; bi += TPB) {\n\
+        device const uint8_t* blk = row + (unsigned long)(bi * 18);\n\
+        float d = f16tof32((uint16_t)blk[0] | ((uint16_t)blk[1] << 8));\n\
+        device const uint8_t* qs = blk + 2;\n\
+        for (int j = 0; j < 32; j++) {\n\
+            int byte_idx = j & 15;\n\
+            int shift = (j < 16) ? 0 : 4;\n\
+            int nib = (qs[byte_idx] >> shift) & 0xF;\n\
+            acc += x[(unsigned long)s * I + bi * 32 + j] * (float)(nib - 8) * d;\n\
+        }\n\
+    }\n\
+    threadgroup float wb[NW];\n\
+    float total = reduce_all(acc, wb, tid);\n\
+    if (tid == 0) y[(unsigned long)s * O + o] = total;\n\
+}\n\
+\n\
+/* ---------------- Q8_0 (34B/32v) — COALESCED, 1 block/simdgroup -----------\n\
+ * 32 lanes read 32 consecutive int8 qs bytes (one coalesced 32B load); each\n\
+ * lane owns value `lane` of the block. d broadcast from L1. */\n\
+kernel void mm_q8_0(device const uint8_t* w [[buffer(0)]],\n\
+                    device const float*   x [[buffer(1)]],\n\
+                    device float*         y [[buffer(2)]],\n\
+                    constant int& I [[buffer(3)]],\n\
+                    constant int& S [[buffer(4)]],\n\
+                    constant int& O [[buffer(5)]],\n\
+                    uint tid [[thread_index_in_threadgroup]],\n\
+                    uint2 gp [[threadgroup_position_in_grid]]) {\n\
+    int o = (int)gp.x, s = (int)gp.y;\n\
+    int nblocks = I / 32;\n\
+    device const uint8_t* row = w + (unsigned long)o * (unsigned long)(nblocks * 34);\n\
+    uint warp = tid >> 5, lane = tid & 31;\n\
+    float acc = 0.0f;\n\
+    for (int bi = (int)warp; bi < nblocks; bi += NW) {\n\
+        device const uint8_t* blk = row + (unsigned long)(bi * 34);\n\
+        float d = f16tof32((uint16_t)blk[0] | ((uint16_t)blk[1] << 8));\n\
+        int8_t q = (int8_t)blk[2 + lane];          // 32 lanes x 1 byte = coalesced\n\
+        acc += x[(unsigned long)s * I + bi * 32 + lane] * (float)q * d;\n\
+    }\n\
+    threadgroup float wb[NW];\n\
+    float total = reduce_all(acc, wb, tid);\n\
+    if (tid == 0) y[(unsigned long)s * O + o] = total;\n\
+}\n\
+\n\
+/* ---------------- Q4_K (144B/256v) — COALESCED, 1 block/simdgroup ---------\n\
+ * The dominant, hot type. One simdgroup (32 lanes) processes one block.\n\
+ * Each lane reads qs[lane*4 .. lane*4+4) -> 4 bytes -> 8 nibbles -> 8 values,\n\
+ * a single coalesced 128-byte read across the simdgroup for the whole qs[128].\n\
+ * Lane g=lane/8 owns superblock group g; within=(lane&7)*4. Indexing derived\n\
+ * from quant.c dequantize_row_q4_K (hand-verified for j in {0,32,64,100}). */\n\
+kernel void mm_q4_K(device const uint8_t* w [[buffer(0)]],\n\
+                    device const float*   x [[buffer(1)]],\n\
+                    device float*         y [[buffer(2)]],\n\
+                    constant int& I [[buffer(3)]],\n\
+                    constant int& S [[buffer(4)]],\n\
+                    constant int& O [[buffer(5)]],\n\
+                    uint tid [[thread_index_in_threadgroup]],\n\
+                    uint2 gp [[threadgroup_position_in_grid]]) {\n\
+    int o = (int)gp.x, s = (int)gp.y;\n\
+    int nblocks = I / 256;\n\
+    device const uint8_t* row = w + (unsigned long)o * (unsigned long)(nblocks * 144);\n\
+    uint warp = tid >> 5, lane = tid & 31;\n\
+    uint g = lane / 8;\n\
+    uint within = (lane & 7) * 4;\n\
+    float acc = 0.0f;\n\
+    for (int bi = (int)warp; bi < nblocks; bi += NW) {\n\
+        device const uint8_t* blk = row + (unsigned long)(bi * 144);\n\
+        float d    = f16tof32((uint16_t)blk[0] | ((uint16_t)blk[1] << 8));\n\
+        float dmin = f16tof32((uint16_t)blk[2] | ((uint16_t)blk[3] << 8));\n\
+        device const uint8_t* scales = blk + 4;\n\
+        device const uint8_t* qs     = blk + 16;\n\
+        float d_lo, m_lo, d_hi, m_hi;\n\
+        k4_unpack(scales, 2 * (int)g,     d_lo, m_lo, d, dmin);\n\
+        k4_unpack(scales, 2 * (int)g + 1, d_hi, m_hi, d, dmin);\n\
+        uint qw = *(device const uint*)(qs + lane * 4);   // 4 bytes, coalesced\n\
+        uint base = (uint)(bi * 256) + g * 64 + within;\n\
+        #pragma unroll\n\
+        for (int k = 0; k < 4; k++) {\n\
+            uint bv = (qw >> (k * 8)) & 0xFF;\n\
+            float lo = (float)(bv & 0xF);\n\
+            float hi = (float)(bv >> 4);\n\
+            acc += x[(unsigned long)s * I + base + k]      * (d_lo * lo - m_lo);\n\
+            acc += x[(unsigned long)s * I + base + k + 32] * (d_hi * hi - m_hi);\n\
+        }\n\
+    }\n\
+    threadgroup float wb[NW];\n\
+    float total = reduce_all(acc, wb, tid);\n\
+    if (tid == 0) y[(unsigned long)s * O + o] = total;\n\
+}\n\
+\n\
+/* ---------------- Q5_K (176B/256v) — metadata cached + simd_sum -----------\n\
+ * block_q5_K: uint16 d, dm, scales[12], qh[32], qs[128]. 5th bit per value in qh. */\n\
+kernel void mm_q5_K(device const uint8_t* w [[buffer(0)]],\n\
+                    device const float*   x [[buffer(1)]],\n\
+                    device float*         y [[buffer(2)]],\n\
+                    constant int& I [[buffer(3)]],\n\
+                    constant int& S [[buffer(4)]],\n\
+                    constant int& O [[buffer(5)]],\n\
+                    uint tid [[thread_index_in_threadgroup]],\n\
+                    uint2 gp [[threadgroup_position_in_grid]]) {\n\
+    int o = (int)gp.x, s = (int)gp.y;\n\
+    int nblocks = I / 256;\n\
+    device const uint8_t* row = w + (unsigned long)o * (unsigned long)(nblocks * 176);\n\
+    float acc = 0.0f;\n\
+    for (int bi = (int)tid; bi < nblocks; bi += TPB) {\n\
+        device const uint8_t* blk = row + (unsigned long)(bi * 176);\n\
+        float d  = f16tof32((uint16_t)blk[0] | ((uint16_t)blk[1] << 8));\n\
+        float dm = f16tof32((uint16_t)blk[2] | ((uint16_t)blk[3] << 8));\n\
+        device const uint8_t* scales = blk + 4;\n\
+        device const uint8_t* qh = blk + 16;\n\
+        device const uint8_t* ql = blk + 48;\n\
+        float dsc[8], dmn[8];\n\
+        for (int is = 0; is < 8; is++) k4_unpack(scales, is, dsc[is], dmn[is], d, dm);\n\
+        for (int j = 0; j < 256; j++) {\n\
+            int sb = j / 64, local = j % 64;\n\
+            int h = local / 32, l = local % 32;\n\
+            int is = sb * 2 + h;\n\
+            uint8_t qlb = ql[sb * 32 + l];\n\
+            int nib = (h == 0) ? (qlb & 0xF) : (qlb >> 4);\n\
+            int hi = (qh[l] >> (sb * 2 + h)) & 1;\n\
+            acc += x[(unsigned long)s * I + bi * 256 + j] * (dsc[is] * (float)(nib + hi * 16) - dmn[is]);\n\
+        }\n\
+    }\n\
+    threadgroup float wb[NW];\n\
+    float total = reduce_all(acc, wb, tid);\n\
+    if (tid == 0) y[(unsigned long)s * O + o] = total;\n\
+}\n\
+\n\
+/* ---------------- Q6_K (210B/256v) — metadata cached + simd_sum -----------\n\
+ * block_q6_K: ql[128], qh[64], scales[16 int8], uint16 d (offset 208). */\n\
+kernel void mm_q6_K(device const uint8_t* w [[buffer(0)]],\n\
+                    device const float*   x [[buffer(1)]],\n\
+                    device float*         y [[buffer(2)]],\n\
+                    constant int& I [[buffer(3)]],\n\
+                    constant int& S [[buffer(4)]],\n\
+                    constant int& O [[buffer(5)]],\n\
+                    uint tid [[thread_index_in_threadgroup]],\n\
+                    uint2 gp [[threadgroup_position_in_grid]]) {\n\
+    int o = (int)gp.x, s = (int)gp.y;\n\
+    int nblocks = I / 256;\n\
+    device const uint8_t* row = w + (unsigned long)o * (unsigned long)(nblocks * 210);\n\
+    float acc = 0.0f;\n\
+    for (int bi = (int)tid; bi < nblocks; bi += TPB) {\n\
+        device const uint8_t* blk = row + (unsigned long)(bi * 210);\n\
+        float d = f16tof32((uint16_t)blk[208] | ((uint16_t)blk[209] << 8));\n\
+        device const uint8_t* ql = blk;\n\
+        device const uint8_t* qh = blk + 128;\n\
+        device const int8_t*  sc = (device const int8_t*)(blk + 192);\n\
+        float ds[16];\n\
+        for (int i = 0; i < 16; i++) ds[i] = d * (float)sc[i];\n\
+        for (int j = 0; j < 256; j++) {\n\
+            int chunk = j / 128, within = j % 128;\n\
+            int sub = within / 32, l = within % 32;\n\
+            int ql_idx = (sub == 1 || sub == 3) ? (l + 32) : l;\n\
+            uint8_t qlb = ql[chunk * 64 + ql_idx];\n\
+            uint8_t qhb = qh[chunk * 32 + l];\n\
+            int qh_shift = (sub == 0) ? 0 : (sub == 1) ? 2 : (sub == 2) ? 4 : 6;\n\
+            int qraw = ((sub < 2) ? (int)(qlb & 0xF) : (int)(qlb >> 4))\n\
+                     | (int)(((qhb >> qh_shift) & 3) << 4);\n\
+            int sc_idx = chunk * 8 + l / 16 + 2 * sub;\n\
+            acc += x[(unsigned long)s * I + bi * 256 + j] * (ds[sc_idx] * (float)(qraw - 32));\n\
+        }\n\
+    }\n\
+    threadgroup float wb[NW];\n\
+    float total = reduce_all(acc, wb, tid);\n\
+    if (tid == 0) y[(unsigned long)s * O + o] = total;\n\
+}\n\
+\n\
+/* ---------------- silu_mul elementwise: gate[i] = silu(gate[i]) * up[i] --- */\n\
+kernel void silu_mul(device float*       gate [[buffer(0)]],\n\
+                     device const float* up   [[buffer(1)]],\n\
+                     constant uint& n   [[buffer(2)]],\n\
+                     uint gid [[thread_position_in_grid]]) {\n\
+    if (gid < n) {\n\
+        float v = gate[gid];\n\
+        gate[gid] = (v / (1.0f + exp(-v))) * up[gid];\n\
+    }\n\
+}\n\
+";
+
+#pragma mark - Device context (single global; Apple Silicon has one GPU)
+
+// Under -fobjc-arc these static globals are strong (retained), released on
+// program exit / shutdown. Apple Silicon exposes exactly one Metal device, so
+// a single context suffices; the `device` ABI param is validated to be 0.
+static id<MTLDevice>            g_device  = nil;
+static id<MTLCommandQueue>       g_queue   = nil;
+static id<MTLLibrary>            g_library = nil;
+static id<MTLComputePipelineState> g_ps_f32, g_ps_f16, g_ps_q4_0, g_ps_q8_0,
+                                  g_ps_q4_K, g_ps_q5_K, g_ps_q6_K, g_ps_silu;
+static int g_ndev = 0;
+
+// Grow-only scratch buffers (mirror CUDA's reserve()). Shared storage mode =
+// unified memory: CPU writes x, GPU reads x & writes y, CPU reads y.
+static id<MTLBuffer> g_x = nil, g_y = nil, g_gate = nil, g_up = nil;
+static size_t g_xcap = 0, g_ycap = 0, g_gatecap = 0, g_upcap = 0;
+
+static id<MTLComputePipelineState> ps_for_qtype(gguf_type_t q) {
+    switch (q) {
+        case GGUF_TYPE_F32:  return g_ps_f32;
+        case GGUF_TYPE_F16:  return g_ps_f16;
+        case GGUF_TYPE_Q4_0: return g_ps_q4_0;
+        case GGUF_TYPE_Q8_0: return g_ps_q8_0;
+        case GGUF_TYPE_Q4_K: return g_ps_q4_K;
+        case GGUF_TYPE_Q5_K: return g_ps_q5_K;
+        case GGUF_TYPE_Q6_K: return g_ps_q6_K;
+        default:             return nil;   /* unsupported -> caller falls back to CPU */
+    }
+}
+
+// Grow-only: only (re)allocates when current capacity is too small.
+// Parameter qualified __strong so we can pass &g_x (a strong global); the
+// default (__autoreleasing*) would reject address-of-strong-global under ARC.
+static id<MTLBuffer> reserve_buf(__strong id<MTLBuffer> *buf, size_t *cap, size_t bytes) {
+    if (*buf && *cap >= bytes) return *buf;
+    *buf = [g_device newBufferWithLength:bytes options:MTLResourceStorageModeShared];
+    if (!*buf) { *cap = 0; return nil; }
+    *cap = bytes;
+    return *buf;
+}
+
+// Row size in bytes for a given qtype / column count (mirrors CUDA gguf_block_size).
+static size_t gguf_row_bytes(gguf_type_t q, int I) {
+    switch (q) {
+        case GGUF_TYPE_F32:  return (size_t)I * 4;
+        case GGUF_TYPE_F16:  return (size_t)I * 2;
+        case GGUF_TYPE_Q4_0: return (size_t)((I / 32) * 18);
+        case GGUF_TYPE_Q8_0: return (size_t)((I / 32) * 34);
+        case GGUF_TYPE_Q4_K: return (size_t)((I / 256) * 144);
+        case GGUF_TYPE_Q5_K: return (size_t)((I / 256) * 176);
+        case GGUF_TYPE_Q6_K: return (size_t)((I / 256) * 210);
+        default:             return 0;
+    }
+}
+
+#pragma mark - Public API (backend_gpu.h)
+
+extern "C" {
+
+int picolm_gpu_init(const int *devices, int count) {
+    if (g_ndev > 0) return 1;                 /* idempotent */
+    if (!devices || count < 1 || count > PICOLM_GPU_MAX_DEVICES) return 0;
+
+    /* Apple Silicon has exactly one GPU; honor only device 0. */
+    int want = devices[0];
+    if (want != 0) {
+        fprintf(stderr, "[Metal] only device 0 is supported on Apple Silicon (asked for %d)\n", want);
+        return 0;
+    }
+
+    g_device = MTLCreateSystemDefaultDevice();
+    if (!g_device) { fprintf(stderr, "[Metal] no Metal device\n"); return 0; }
+    g_queue = [g_device newCommandQueue];
+    if (!g_queue) { g_device = nil; return 0; }
+
+    NSError *err = nil;
+    g_library = [g_device newLibraryWithSource:KERNEL_SOURCE options:nil error:&err];
+    if (!g_library) {
+        fprintf(stderr, "[Metal] kernel compile failed: %s\n",
+                [[err localizedDescription] UTF8String]);
+        g_device = nil; g_queue = nil; return 0;
+    }
+    /* Eagerly build all pipeline states (one compile per function). */
+    g_ps_f32  = [g_device newComputePipelineStateWithFunction:[g_library newFunctionWithName:@"mm_f32"]  error:&err];
+    g_ps_f16  = [g_device newComputePipelineStateWithFunction:[g_library newFunctionWithName:@"mm_f16"]  error:nil];
+    g_ps_q4_0 = [g_device newComputePipelineStateWithFunction:[g_library newFunctionWithName:@"mm_q4_0"] error:nil];
+    g_ps_q8_0 = [g_device newComputePipelineStateWithFunction:[g_library newFunctionWithName:@"mm_q8_0"] error:nil];
+    g_ps_q4_K = [g_device newComputePipelineStateWithFunction:[g_library newFunctionWithName:@"mm_q4_K"] error:nil];
+    g_ps_q5_K = [g_device newComputePipelineStateWithFunction:[g_library newFunctionWithName:@"mm_q5_K"] error:nil];
+    g_ps_q6_K = [g_device newComputePipelineStateWithFunction:[g_library newFunctionWithName:@"mm_q6_K"] error:nil];
+    g_ps_silu = [g_device newComputePipelineStateWithFunction:[g_library newFunctionWithName:@"silu_mul"] error:nil];
+    if (!g_ps_f32 || !g_ps_f16 || !g_ps_q4_0 || !g_ps_q8_0 || !g_ps_q4_K || !g_ps_q5_K || !g_ps_q6_K || !g_ps_silu) {
+        fprintf(stderr, "[Metal] pipeline state creation failed\n");
+        g_device = nil; g_queue = nil; g_library = nil; return 0;
+    }
+
+    g_ndev = 1;
+    fprintf(stderr, "[Metal] device: %s, working set %.1f GB\n",
+            [[g_device name] UTF8String],
+            (double)[g_device recommendedMaxWorkingSetSize] / 1e9);
+    return 1;
+}
+
+void picolm_gpu_shutdown(void) {
+    g_x = g_y = g_gate = g_up = nil;
+    g_xcap = g_ycap = g_gatecap = g_upcap = 0;
+    g_ps_f32 = g_ps_f16 = g_ps_q4_0 = g_ps_q8_0 = g_ps_q4_K = g_ps_q5_K = g_ps_q6_K = g_ps_silu = nil;
+    g_library = nil; g_queue = nil; g_device = nil;
+    g_ndev = 0;
+}
+
+int  picolm_gpu_device_count(void)            { return g_ndev; }
+int  picolm_gpu_device_at(int index)          { return (index == 0 && g_ndev > 0) ? 0 : -1; }
+
+int picolm_gpu_mem_info(int device, size_t *free_bytes, size_t *total_bytes) {
+    if (device != 0 || !g_device || !free_bytes || !total_bytes) return 0;
+    size_t ws = [g_device recommendedMaxWorkingSetSize];
+    *total_bytes = ws;
+    *free_bytes  = ws;    /* Metal exposes no precise "free"; report the budget. */
+    return 1;
+}
+
+struct picolm_gpu_tensor {
+    void *weights;         /* id<MTLBuffer> (bridged-retained under ARC) */
+    gguf_type_t qtype;
+    int I, O, device;
+    size_t row_bytes;
+    size_t buf_offset;     /* byte offset of the tensor within its MTLBuffer */
+    int zero_copy;
+};
+
+// NOTE: param is `void**` (not picolm_gpu_tensor_t**) to match the extern "C"
+// declaration in backend_gpu.h. A T** definition against a void** decl does
+// NOT match in C++ -> it would emit a mangled symbol and fail to link against
+// model.o (compiled as C, which references the unmangled name). Verified.
+int picolm_gpu_tensor_upload(void **tensor,
+                              const void *weights,
+                              gguf_type_t qtype, int I, int O, int device) {
+    if (!tensor || !weights || I < 1 || O < 1 || device != 0 || !g_device) return 0;
+    if (!ps_for_qtype(qtype)) return 0;       /* unsupported type -> CPU fallback (handle stays NULL) */
+    if (*tensor) return 1;                    /* idempotent */
+
+    size_t row_bytes = gguf_row_bytes(qtype, I);
+    if (!row_bytes) return 0;
+    size_t total = row_bytes * (size_t)O;
+
+    id<MTLBuffer> buf = nil;
+    int zero_copy = 0;
+    size_t buf_offset = 0;
+
+    /* Zero-copy on Apple Silicon is essential for big models: a 27B model is
+     * ~16 GB, and COPYING it into Metal buffers doubles resident memory and
+     * blows the GPU working set -> unified-memory paging -> catastrophic
+     * slowdown. newBufferWithBytesNoCopy: needs BOTH pointer and length to be
+     * page-aligned, which per-tensor pointers rarely are. So we page-align
+     * DOWN the pointer and UP the length, register the aligned region, and
+     * bind the tensor at its offset within that region. This makes almost every
+     * tensor zero-copy with no per-tensor copy and no extra RAM. (If Metal
+     * rejects the region — e.g. some overlap cases — we fall back to copy.) */
+    size_t page = (size_t)getpagesize();
+    uintptr_t addr = (uintptr_t)weights;
+    uintptr_t base_addr = addr & ~(uintptr_t)(page - 1);   /* round down to page */
+    size_t pad_lo = (size_t)(addr - base_addr);
+    size_t aligned_len = (total + pad_lo + page - 1) & ~(page - 1);  /* round up */
+    buf = [g_device newBufferWithBytesNoCopy:(void *)base_addr
+                                      length:aligned_len
+                                      options:MTLResourceStorageModeShared |
+                                               MTLResourceCPUCacheModeDefaultCache
+                                      deallocator:^(void *ptr, NSUInteger len) {
+                                          /* mmap'd memory is owned by the model; nothing to free. */
+                                          (void)ptr; (void)len;
+                                      }];
+    if (buf) {
+        zero_copy = 1;
+        buf_offset = pad_lo;
+    } else {
+        /* Fallback: one-time copy into a shared-storage buffer (offset 0). */
+        buf = [g_device newBufferWithBytes:weights length:total options:MTLResourceStorageModeShared];
+        buf_offset = 0;
+    }
+    if (!buf) {
+        fprintf(stderr, "[Metal] OOM uploading tensor: I=%d O=%d qtype=%d (%.1f MB)\n",
+                I, O, (int)qtype, (double)total / (1024.0 * 1024.0));
+        return 0;
+    }
+
+    picolm_gpu_tensor_t *t = (picolm_gpu_tensor_t *)calloc(1, sizeof(*t));
+    if (!t) { return 0; }
+    t->weights    = (__bridge_retained void *)buf;   /* ARC: transfer ownership to void* */
+    t->qtype      = qtype;
+    t->I          = I;
+    t->O          = O;
+    t->device     = device;
+    t->row_bytes  = row_bytes;
+    t->buf_offset = buf_offset;
+    t->zero_copy  = zero_copy;
+
+    static int first = 1;
+    if (first) { fprintf(stderr, "[Metal] upload mode: %s\n", zero_copy ? "zero-copy" : "copied"); first = 0; }
+
+    *tensor = t;
+    return 1;
+}
+
+void picolm_gpu_tensor_free(picolm_gpu_tensor_t *t) {
+    if (!t) return;
+    if (t->weights) {
+        /* Reclaim the bridged-retained MTLBuffer so ARC releases it. */
+        id<MTLBuffer> buf = (__bridge_transfer id<MTLBuffer>)t->weights;
+        (void)buf;
+        t->weights = NULL;
+    }
+    free(t);
+}
+
+size_t picolm_gpu_tensor_bytes(const picolm_gpu_tensor_t *t) {
+    return t ? t->row_bytes * (size_t)t->O : 0;
+}
+int picolm_gpu_tensor_device(const picolm_gpu_tensor_t *t) {
+    return t ? t->device : -1;
+}
+
+// Encode one quant_matmul: y[S*O] = x[S*I] @ W[O,I]^T, weights already resident.
+static int launch_matmul(picolm_gpu_tensor_t *t, id<MTLBuffer> xbuf, id<MTLBuffer> ybuf,
+                          int S, id<MTLCommandBuffer> cmd) {
+    id<MTLComputePipelineState> ps = ps_for_qtype(t->qtype);
+    if (!ps) return 0;
+    int I = t->I, O = t->O;
+    id<MTLComputeCommandEncoder> enc = [cmd computeCommandEncoder];
+    [enc setComputePipelineState:ps];
+    [enc setBuffer:(__bridge id<MTLBuffer>)t->weights offset:t->buf_offset atIndex:0];
+    [enc setBuffer:xbuf offset:0 atIndex:1];
+    [enc setBuffer:ybuf offset:0 atIndex:2];
+    int32_t cI = I, cS = S, cO = O;
+    [enc setBytes:&cI length:sizeof(cI) atIndex:3];
+    [enc setBytes:&cS length:sizeof(cS) atIndex:4];
+    [enc setBytes:&cO length:sizeof(cO) atIndex:5];
+    [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)O, (NSUInteger)S, 1)
+        threadsPerThreadgroup:MTLSizeMake(TPB, 1, 1)];
+    [enc endEncoding];
+    return 1;
+}
+
+int picolm_gpu_matmul(picolm_gpu_tensor_t *t, float *y, const float *x, int S, int device) {
+    if (!t || !y || !x || S < 1 || device != 0 || !g_device) return 0;
+    int I = t->I, O = t->O;
+    size_t xb = (size_t)S * I * sizeof(float);
+    size_t yb = (size_t)S * O * sizeof(float);
+    if (!reserve_buf(&g_x, &g_xcap, xb)) return 0;
+    if (!reserve_buf(&g_y, &g_ycap, yb)) return 0;
+
+    memcpy([g_x contents], x, xb);
+
+    id<MTLCommandBuffer> cmd = [g_queue commandBuffer];
+    if (!launch_matmul(t, g_x, g_y, S, cmd)) { return 0; }
+    [cmd commit];
+    [cmd waitUntilCompleted];
+
+    memcpy(y, [g_y contents], yb);
+    return 1;
+}
+
+int picolm_gpu_expert_mlp(picolm_gpu_tensor_t *gate, picolm_gpu_tensor_t *up,
+                           picolm_gpu_tensor_t *down, float *y, const float *x, int S) {
+    if (!gate || !up || !down || !x || !y || S < 1) return 0;
+    if (gate->device != up->device || gate->device != down->device || gate->device != 0) return 0;
+    if (gate->I != up->I || gate->O != up->O ||
+        down->I != gate->O || down->O != gate->I) return 0;
+
+    int D = gate->I, I = gate->O;
+    size_t xb = (size_t)S * D * sizeof(float);
+    size_t ib = (size_t)S * I * sizeof(float);
+    if (!reserve_buf(&g_x,    &g_xcap,    xb)) return 0;
+    if (!reserve_buf(&g_y,    &g_ycap,    xb)) return 0;
+    if (!reserve_buf(&g_gate, &g_gatecap, ib)) return 0;
+    if (!reserve_buf(&g_up,   &g_upcap,   ib)) return 0;
+
+    memcpy([g_x contents], x, xb);
+
+    id<MTLCommandBuffer> cmd = [g_queue commandBuffer];
+    /* gate = W_gate @ x ; up = W_up @ x */
+    if (!launch_matmul(gate, g_x, g_gate, S, cmd)) return 0;
+    if (!launch_matmul(up,   g_x, g_up,   S, cmd)) return 0;
+    /* silu(gate) * up  -> gate */
+    {
+        id<MTLComputeCommandEncoder> enc = [cmd computeCommandEncoder];
+        [enc setComputePipelineState:g_ps_silu];
+        [enc setBuffer:g_gate offset:0 atIndex:0];
+        [enc setBuffer:g_up   offset:0 atIndex:1];
+        uint32_t n = (uint32_t)(S * I);
+        [enc setBytes:&n length:sizeof(n) atIndex:2];
+        NSUInteger ngrid = (n + TPB - 1) / TPB;
+        [enc dispatchThreadgroups:MTLSizeMake(ngrid, 1, 1)
+            threadsPerThreadgroup:MTLSizeMake(TPB, 1, 1)];
+        [enc endEncoding];
+    }
+    /* y = W_down @ gate */
+    if (!launch_matmul(down, g_gate, g_y, S, cmd)) return 0;
+    [cmd commit];
+    [cmd waitUntilCompleted];
+
+    memcpy(y, [g_y contents], xb);
+    return 1;
+}
+
+// Not implemented in v1: Apple GPUs have their own matrix accelerator but
+// exposing it cleanly is a separate task. Returning 0 makes the caller
+// (tensor.c / model.c) fall back to the quant_matmul path, which is correct.
+int picolm_gpu_w4a16_mlp(picolm_gpu_tensor_t *gate, picolm_gpu_tensor_t *up,
+                          picolm_gpu_tensor_t *down, float *y, const float *x, int S) {
+    (void)gate; (void)up; (void)down; (void)y; (void)x; (void)S;
+    return 0;
+}
+
+// The three entry points below are referenced by the host under -DPICOLM_GPU=1
+// (tensor.c picolm_gpu_w4a16_matmul; model.c ssm_vecdot/ssm_recurrence) but are
+// not implemented for Metal in v1. Returning 0 makes the caller fall back to
+// the CPU (quant_matmul / SSM) path, which is correct. These stubs are required
+// for `make metal` to link against the current host code (which gained these
+// GPU hooks after the Metal backend was first written). Verified needed via:
+//   cc -DPICOLM_GPU=1 -c model.c tensor.c && nm -u *.o | grep picolm_gpu
+int picolm_gpu_w4a16_matmul(picolm_gpu_tensor_t *t,
+                             float *y, const float *x, int S, int device) {
+    (void)t; (void)y; (void)x; (void)S; (void)device;
+    return 0;   /* CPU fallback (WMMA Tensor Core path not exposed on Apple GPUs yet) */
+}
+
+int picolm_gpu_ssm_vecdot(float *out,
+                           const float *x,
+                           const void *weights,
+                           gguf_type_t qtype,
+                           int dim, int n_v_heads,
+                           int row_bytes,
+                           const int *head_map,
+                           int device) {
+    (void)out; (void)x; (void)weights; (void)qtype; (void)dim;
+    (void)n_v_heads; (void)row_bytes; (void)head_map; (void)device;
+    return 0;   /* CPU fallback (SSM alpha/beta vec_dot) */
+}
+
+int picolm_gpu_ssm_recurrence(float *state,
+                               const float *q_conv,
+                               const float *k_conv,
+                               const float *v_conv,
+                               const float *gate_exp,
+                               const float *beta,
+                               float *ssm_output,
+                               int n_v_heads, int d_state,
+                               int repeat, int device) {
+    (void)state; (void)q_conv; (void)k_conv; (void)v_conv; (void)gate_exp;
+    (void)beta; (void)ssm_output; (void)n_v_heads; (void)d_state;
+    (void)repeat; (void)device;
+    return 0;   /* CPU fallback (per-head SSM recurrence) */
+}
+
+}  // extern "C"

--- a/picolm/backend_metal.mm
+++ b/picolm/backend_metal.mm
@@ -64,8 +64,9 @@
 //     derived from quant.c dequantize_row_q4_K and hand-verified.
 //   - Q8_0: 1 block (34B, 32 values) per simdgroup; each lane reads 1 int8.
 //   - F32/F16: float4 / half4 vector loads, lanes stride by TPB*4.
-// Q4_0/Q5_K/Q6_K keep a per-element structure (their layouts are awkward to
-// coalesce) but cache block metadata once and use simd_sum.
+// Q4_0/Q5_K keep a per-element structure (their layouts are awkward to
+// coalesce) but cache block metadata once and use simd_sum. Q6_K is ALSO
+// coalesced (1 block/simdgroup, 8 values/lane) — see mm_q6_K below.
 //
 // IMPORTANT: dequant layouts match PicoLM's CPU dequantize_row_* in quant.c
 // (the GGUF/llama.cpp convention). For Q4_0: value j -> byte (j&15), low nibble
@@ -296,8 +297,12 @@ kernel void mm_q5_K(device const uint8_t* w [[buffer(0)]],\n\
     if (tid == 0) y[(unsigned long)s * O + o] = total;\n\
 }\n\
 \n\
-/* ---------------- Q6_K (210B/256v) — metadata cached + simd_sum -----------\n\
- * block_q6_K: ql[128], qh[64], scales[16 int8], uint16 d (offset 208). */\n\
+/* ---------------- Q6_K (210B/256v) — COALESCED, 1 block/simdgroup ---------\n\
+ * One simdgroup (32 lanes) processes one 256-value block; each lane owns 8\n\
+ * values. ql[128] read in 4 coalesced 32B passes (lane t owns bytes t,32+t,\n\
+ * 64+t,96+t); qh[64] in 2 coalesced passes; scales read direct (cached).\n\
+ * Indexing derived from quant.c dequantize_row_q6_K; validated vs the CPU\n\
+ * reference by probes/metal_matmul_bench (4-11x faster than per-element). */\n\
 kernel void mm_q6_K(device const uint8_t* w [[buffer(0)]],\n\
                     device const float*   x [[buffer(1)]],\n\
                     device float*         y [[buffer(2)]],\n\
@@ -309,26 +314,30 @@ kernel void mm_q6_K(device const uint8_t* w [[buffer(0)]],\n\
     int o = (int)gp.x, s = (int)gp.y;\n\
     int nblocks = I / 256;\n\
     device const uint8_t* row = w + (unsigned long)o * (unsigned long)(nblocks * 210);\n\
+    uint warp = tid >> 5, lane = tid & 31;\n\
     float acc = 0.0f;\n\
-    for (int bi = (int)tid; bi < nblocks; bi += TPB) {\n\
+    for (int bi = (int)warp; bi < nblocks; bi += NW) {\n\
         device const uint8_t* blk = row + (unsigned long)(bi * 210);\n\
         float d = f16tof32((uint16_t)blk[208] | ((uint16_t)blk[209] << 8));\n\
         device const uint8_t* ql = blk;\n\
         device const uint8_t* qh = blk + 128;\n\
         device const int8_t*  sc = (device const int8_t*)(blk + 192);\n\
-        float ds[16];\n\
-        for (int i = 0; i < 16; i++) ds[i] = d * (float)sc[i];\n\
-        for (int j = 0; j < 256; j++) {\n\
-            int chunk = j / 128, within = j % 128;\n\
-            int sub = within / 32, l = within % 32;\n\
-            int ql_idx = (sub == 1 || sub == 3) ? (l + 32) : l;\n\
-            uint8_t qlb = ql[chunk * 64 + ql_idx];\n\
-            uint8_t qhb = qh[chunk * 32 + l];\n\
-            int qh_shift = (sub == 0) ? 0 : (sub == 1) ? 2 : (sub == 2) ? 4 : 6;\n\
-            int qraw = ((sub < 2) ? (int)(qlb & 0xF) : (int)(qlb >> 4))\n\
-                     | (int)(((qhb >> qh_shift) & 3) << 4);\n\
-            int sc_idx = chunk * 8 + l / 16 + 2 * sub;\n\
-            acc += x[(unsigned long)s * I + bi * 256 + j] * (ds[sc_idx] * (float)(qraw - 32));\n\
+        #pragma unroll\n\
+        for (int k = 0; k < 4; k++) {            /* 4 coalesced 32B ql reads */\n\
+            uint b   = (uint)(k * 32) + lane;     /* ql byte this lane owns   */\n\
+            uint chk = b >> 6;                     /* chunk = b/64            */\n\
+            uint grp = (b & 63) >> 5;             /* (b%64)/32               */\n\
+            uint l   = b & 31;                     /* b%32                    */\n\
+            uint qlb = ql[b];                      /* coalesced               */\n\
+            uint qhb = qh[chk * 32 + l];\n\
+            int qraw0 = (int)(qlb & 0xF) | (int)(((qhb >> (2u * grp)) & 3u) << 4);\n\
+            int si0   = (int)(chk * 8 + l / 16 + 2u * grp);\n\
+            uint j0   = chk * 128 + grp * 32 + l;\n\
+            acc += x[(unsigned long)s * I + (unsigned long)bi * 256 + j0] * (d * (float)sc[si0] * (float)(qraw0 - 32));\n\
+            int qraw1 = (int)(qlb >> 4) | (int)(((qhb >> (2u * (grp + 2u))) & 3u) << 4);\n\
+            int si1   = (int)(chk * 8 + l / 16 + 2u * (grp + 2u));\n\
+            uint j1   = chk * 128 + (grp + 2u) * 32 + l;\n\
+            acc += x[(unsigned long)s * I + (unsigned long)bi * 256 + j1] * (d * (float)sc[si1] * (float)(qraw1 - 32));\n\
         }\n\
     }\n\
     threadgroup float wb[NW];\n\

--- a/picolm/picolm.c
+++ b/picolm/picolm.c
@@ -312,8 +312,12 @@ int main(int argc, char **argv) {
     fprintf(stderr, "SIMD: scalar\n");
 #endif
 
-    /* Runtime check: warn if CPU supports I8MM but compiler didn't enable it */
-#if defined(__aarch64__) && !defined(PICOLM_I8MM) && !defined(_WIN32)
+    /* Runtime check: warn if CPU supports I8MM but compiler didn't enable it.
+     * Linux-only: it reads the ELF auxiliary vector (getauxval/AT_HWCAP2),
+     * which does not exist on macOS. Apple Silicon is __aarch64__ too, so it
+     * must be excluded explicitly (this also broke the macOS/`make metal` and
+     * `make native` builds with "sys/auxv.h not found"). */
+#if defined(__aarch64__) && !defined(PICOLM_I8MM) && !defined(_WIN32) && !defined(__APPLE__)
     {
         #include <sys/auxv.h>
         #include <elf.h>

--- a/picolm/probes/metal_matmul_bench.mm
+++ b/picolm/probes/metal_matmul_bench.mm
@@ -1,0 +1,311 @@
+// probes/metal_matmul_bench.mm
+//
+// Benchmark + correctness harness for the PicoLM Metal matmul kernels.
+// Build:  make metal-bench      Run:  ./probes/metal_matmul_bench
+//
+// What it does (all in one binary, no model file needed):
+//   1. Compiles the SAME MSL kernels the backend uses (copied verbatim from
+//      backend_metal.mm KERNEL_SOURCE) + a new coalesced Q6_K variant
+//      (mm_q6_K_c) under test.
+//   2. CORRECTNESS: for small dims (1-2 blocks) diffs GPU output vs a CPU
+//      reference (ported from quant.c dequantize_row_q4_K/q6_K). Catches any
+//      dequant-index regression BEFORE it reaches the model.
+//   3. THROUGHPUT: times each kernel at TinyLlama-relevant dims (decode S=1 and
+//      prefill S=32/128) and reports ms/iter and effective weight bandwidth.
+//   4. DISPATCH OVERHEAD: empty-kernel commit+waitUntilCompleted round-trip,
+//      so we can tell whether kernels or host launch/sync is the bottleneck.
+//
+// NOTE: the kernel block below MUST mirror picolm/backend_metal.mm KERNEL_SOURCE.
+// If you change the kernels there, paste the same change here (search MIRROR).
+
+#include <metal/Metal.h>
+#include <Foundation/Foundation.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <mach/mach_time.h>
+
+#define TPB 256
+#define NW  (TPB/32)
+
+enum { T_F32 = 0, T_F16, T_Q4_0, T_Q8_0, T_Q4K, T_Q5K, T_Q6K };
+
+// ---------------- host fp16 <-> fp32 (matches quant.c software path) ----------------
+static float fp16tof32(uint16_t h) {
+    uint32_t sign=(h>>15)&1, exp=(h>>10)&0x1f, mant=h&0x3ff, f;
+    if (exp==0) { if(mant==0){f=sign<<31;} else {exp=1; while(!(mant&0x400)){mant<<=1;exp--;} mant&=0x3ff; f=(sign<<31)|((exp+127-15)<<23)|(mant<<13);} }
+    else { f=(sign<<31)|((exp+127-15)<<23)|(mant<<13); }
+    float o; memcpy(&o,&f,4); return o;
+}
+static uint16_t fp32tofp16(float f) {
+    uint32_t x; memcpy(&x,&f,4);
+    uint32_t sign=(x>>16)&0x8000; int32_t exp=(int32_t)((x>>23)&0xff)-127+15; uint32_t mant=x&0x7fffff;
+    if (exp<=0){ if(exp<-10) return sign; mant|=0x800000; uint32_t sh=(uint32_t)(14-exp); uint32_t mo=mant>>sh; if((mant>>(sh-1))&1)mo++; return sign|mo; }
+    else if (exp>=0x1f) return sign|0x7c00;
+    uint32_t o=sign|((uint32_t)exp<<10)|(mant>>13); if((mant>>12)&1)o++; return o;
+}
+static void put_fp16(uint8_t* p, float v){ uint16_t h=fp32tofp16(v); p[0]=h&0xFF; p[1]=(h>>8)&0xFF; }
+
+// ---------------- CPU dequant references (ported from quant.c) ----------------
+static void get_scale_min_k4(int j, const uint8_t* q, uint8_t* sc, uint8_t* mn) {
+    if (j<4){ *sc=q[j]&63; *mn=q[j+4]&63; }
+    else { *sc=(q[j+4]&0xF)|((q[j-4]>>6)<<4); *mn=(q[j+4]>>4)|((q[j]>>6)<<4); }
+}
+static void deq_q4_K(const uint8_t* src, float* dst, int n) {
+    int nb=n/256;
+    for (int i=0;i<nb;i++){ const uint8_t* b=src+i*144;
+        float d=fp16tof32(b[0]|(b[1]<<8)), dmin=fp16tof32(b[2]|(b[3]<<8));
+        const uint8_t* sc=b+4; const uint8_t* q=b+16; float* y=dst+i*256; int is=0;
+        for (int j=0;j<4;j++){ uint8_t s,m; get_scale_min_k4(is,sc,&s,&m); float d1=d*s,m1=dmin*m;
+            get_scale_min_k4(is+1,sc,&s,&m); float d2=d*s,m2=dmin*m;
+            for(int l=0;l<32;l++) y[l]    =d1*(float)(q[l]&0xF)-m1;
+            for(int l=0;l<32;l++) y[l+32] =d2*(float)(q[l]>>4)-m2;
+            y+=64; q+=32; is+=2; }
+    }
+}
+static void deq_q6_K(const uint8_t* src, float* dst, int n) {
+    int nb=n/256;
+    for (int i=0;i<nb;i++){ const uint8_t* blk=src+i*210;
+        float d=fp16tof32(blk[208]|(blk[209]<<8));
+        const uint8_t* ql=blk; const uint8_t* qh=blk+128; const int8_t* sc=(const int8_t*)(blk+192);
+        float* y=dst+i*256;
+        for (int chunk=0;chunk<256;chunk+=128){ int is=chunk/16;
+            for (int l=0;l<32;l++){
+                int q1=(int)((ql[l]&0xF)|(((qh[l]>>0)&3)<<4))-32;
+                int q2=(int)((ql[l+32]&0xF)|(((qh[l]>>2)&3)<<4))-32;
+                int q3=(int)((ql[l]>>4)|(((qh[l]>>4)&3)<<4))-32;
+                int q4=(int)((ql[l+32]>>4)|(((qh[l]>>6)&3)<<4))-32;
+                int is_l=is+(l/16);
+                y[l]   =d*(float)sc[is_l+0]*(float)q1; y[l+32]=d*(float)sc[is_l+2]*(float)q2;
+                y[l+64]=d*(float)sc[is_l+4]*(float)q3; y[l+96]=d*(float)sc[is_l+6]*(float)q4;
+            }
+            y+=128; ql+=64; qh+=32;
+        }
+    }
+}
+// dequant one weight row, dot with xrow -> scalar
+static float cpu_dot(const uint8_t* wrow, const float* xrow, int I, int qtype, float* tmp) {
+    if (qtype==T_Q4K) deq_q4_K(wrow,tmp,I); else deq_q6_K(wrow,tmp,I);
+    double acc=0; for (int i=0;i<I;i++) acc+=(double)tmp[i]*(double)xrow[i]; return (float)acc;
+}
+
+// ---------------- random quantized weight block generation ----------------
+static uint8_t rb(void){ return (uint8_t)(rand()&0xFF); }
+// Fill O rows of 'row_bytes' each with random-but-valid blocks (controlled fp16 scales).
+static void gen_weights(uint8_t* w, int O, size_t row_bytes, int qtype) {
+    int bsz = (qtype==T_Q4K)?144:210;   // bytes per 256-value block
+    for (int o=0;o<O;o++){
+        uint8_t* row = w + (size_t)o*row_bytes;
+        int nblocks = (int)(row_bytes/bsz);
+        for (int bi=0;bi<nblocks;bi++){
+            uint8_t* blk = row + bi*bsz;
+            for (int i=0;i<bsz;i++) blk[i]=rb();
+            if (qtype==T_Q4K){ put_fp16(blk+0, 0.02f+0.01f*(bi&3)); put_fp16(blk+2, 0.01f*(bi&1)); }
+            else             { put_fp16(blk+208, 0.02f+0.01f*(bi&3)); }
+        }
+    }
+}
+
+// ================= MSL KERNEL SOURCE (MIRROR of backend_metal.mm) =================
+static NSString* KS = @"\
+#include <metal_stdlib>\n\
+using namespace metal;\n\
+inline float f16tof32(uint16_t h){ return (float)as_type<half>(h); }\n\
+#define TPB 256\n\
+#define NW (TPB/32)\n\
+inline float reduce_all(float acc, threadgroup float* wb, uint tid){\n\
+    uint warp=tid>>5, lane=tid&31; acc=simd_sum(acc);\n\
+    if(lane==0) wb[warp]=acc; threadgroup_barrier(mem_flags::mem_threadgroup);\n\
+    float v=(warp==0&&lane<NW)?wb[lane]:0.0f; return simd_sum(v);\n\
+}\n\
+inline void k4_unpack(device const uint8_t* s,int is,thread float& dsc,thread float& dmn,float d,float dmin){\n\
+    uint8_t sc,mn; if(is<4){sc=s[is]&63;mn=s[is+4]&63;}else{sc=(s[is+4]&0xF)|((s[is-4]>>6)<<4);mn=(s[is+4]>>4)|((s[is]>>6)<<4);}\n\
+    dsc=d*(float)sc; dmn=dmin*(float)mn;\n\
+}\n\
+/* ---- Q4_K (current backend kernel, verbatim) ---- */\n\
+kernel void mm_q4_K(device const uint8_t* w [[buffer(0)]],device const float* x [[buffer(1)]],device float* y [[buffer(2)]],\n\
+   constant int& I [[buffer(3)]],constant int& S [[buffer(4)]],constant int& O [[buffer(5)]],\n\
+   uint tid [[thread_index_in_threadgroup]],uint2 gp [[threadgroup_position_in_grid]]){\n\
+    int o=(int)gp.x,s=(int)gp.y; int nblocks=I/256;\n\
+    device const uint8_t* row=w+(unsigned long)o*(unsigned long)(nblocks*144);\n\
+    uint warp=tid>>5,lane=tid&31,g=lane/8,within=(lane&7)*4; float acc=0.0f;\n\
+    for(int bi=(int)warp;bi<nblocks;bi+=NW){ device const uint8_t* blk=row+(unsigned long)(bi*144);\n\
+        float d=f16tof32((uint16_t)blk[0]|((uint16_t)blk[1]<<8)); float dmin=f16tof32((uint16_t)blk[2]|((uint16_t)blk[3]<<8));\n\
+        device const uint8_t* scales=blk+4; device const uint8_t* qs=blk+16;\n\
+        float d_lo,m_lo,d_hi,m_hi; k4_unpack(scales,2*(int)g,d_lo,m_lo,d,dmin); k4_unpack(scales,2*(int)g+1,d_hi,m_hi,d,dmin);\n\
+        uint qw=*(device const uint*)(qs+lane*4); uint base=(uint)(bi*256)+g*64+within;\n\
+        for(int k=0;k<4;k++){ uint bv=(qw>>(k*8))&0xFF; float lo=(float)(bv&0xF),hi=(float)(bv>>4);\n\
+            acc+=x[(unsigned long)s*I+base+k]*(d_lo*lo-m_lo); acc+=x[(unsigned long)s*I+base+k+32]*(d_hi*hi-m_hi); }\n\
+    }\n\
+    threadgroup float wb[NW]; float total=reduce_all(acc,wb,tid); if(tid==0) y[(unsigned long)s*O+o]=total;\n\
+}\n\
+/* ---- Q6_K (current backend kernel, verbatim) ---- */\n\
+kernel void mm_q6_K(device const uint8_t* w [[buffer(0)]],device const float* x [[buffer(1)]],device float* y [[buffer(2)]],\n\
+   constant int& I [[buffer(3)]],constant int& S [[buffer(4)]],constant int& O [[buffer(5)]],\n\
+   uint tid [[thread_index_in_threadgroup]],uint2 gp [[threadgroup_position_in_grid]]){\n\
+    int o=(int)gp.x,s=(int)gp.y; int nblocks=I/256;\n\
+    device const uint8_t* row=w+(unsigned long)o*(unsigned long)(nblocks*210);\n\
+    float acc=0.0f;\n\
+    for(int bi=(int)tid;bi<nblocks;bi+=TPB){ device const uint8_t* blk=row+(unsigned long)(bi*210);\n\
+        float d=f16tof32((uint16_t)blk[208]|((uint16_t)blk[209]<<8));\n\
+        device const uint8_t* ql=blk; device const uint8_t* qh=blk+128; device const int8_t* sc=(device const int8_t*)(blk+192);\n\
+        for(int j=0;j<256;j++){ int chunk=j/128,within=j%128,sub=within/32,l=within%32;\n\
+            int ql_idx=(sub==1||sub==3)?(l+32):l; uint8_t qlb=ql[chunk*64+ql_idx]; uint8_t qhb=qh[chunk*32+l];\n\
+            int qh_shift=(sub==0)?0:(sub==1)?2:(sub==2)?4:6;\n\
+            int qraw=((sub<2)?(int)(qlb&0xF):(int)(qlb>>4))|(int)(((qhb>>qh_shift)&3)<<4);\n\
+            int sc_idx=chunk*8+l/16+2*sub; acc+=x[(unsigned long)s*I+bi*256+j]*(d*(float)sc[sc_idx]*(float)(qraw-32));\n\
+        }\n\
+    }\n\
+    threadgroup float wb[NW]; float total=reduce_all(acc,wb,tid); if(tid==0) y[(unsigned long)s*O+o]=total;\n\
+}\n\
+/* ---- Q6_K COALESCED variant under test (mm_q6_K_c) ----\n\
+ * One simdgroup (32 lanes) per 256-value block; each lane owns 8 values.\n\
+ * ql[128] read in 4 coalesced 32B passes (lane t owns bytes t,32+t,64+t,96+t);\n\
+ * qh[64] in 2 coalesced passes; scales read direct (cached). Indexing derived\n\
+ * from quant.c dequantize_row_q6_K and hand-traced for values j=0,32,96,128. */\n\
+kernel void mm_q6_K_c(device const uint8_t* w [[buffer(0)]],device const float* x [[buffer(1)]],device float* y [[buffer(2)]],\n\
+   constant int& I [[buffer(3)]],constant int& S [[buffer(4)]],constant int& O [[buffer(5)]],\n\
+   uint tid [[thread_index_in_threadgroup]],uint2 gp [[threadgroup_position_in_grid]]){\n\
+    int o=(int)gp.x,s=(int)gp.y; int nblocks=I/256;\n\
+    device const uint8_t* row=w+(unsigned long)o*(unsigned long)(nblocks*210);\n\
+    uint warp=tid>>5,lane=tid&31; float acc=0.0f;\n\
+    for(int bi=(int)warp;bi<nblocks;bi+=NW){ device const uint8_t* blk=row+(unsigned long)(bi*210);\n\
+        float d=f16tof32((uint16_t)blk[208]|((uint16_t)blk[209]<<8));\n\
+        device const uint8_t* ql=blk; device const uint8_t* qh=blk+128; device const int8_t* sc=(device const int8_t*)(blk+192);\n\
+        for(int k=0;k<4;k++){ uint b=(uint)(k*32)+lane; uint chk=b>>6,grp=(b&63)>>5,l=b&31;\n\
+            uint qlb=ql[b]; uint qhb=qh[chk*32+l];\n\
+            int qr0=(int)(qlb&0xF)|(int)(((qhb>>(2u*grp))&3u)<<4);   int si0=(int)(chk*8+l/16+2u*grp);     uint j0=chk*128+grp*32+l;\n\
+            acc+=x[(unsigned long)s*I+(unsigned long)bi*256+j0]*(d*(float)sc[si0]*(float)(qr0-32));\n\
+            int qr1=(int)(qlb>>4)|(int)(((qhb>>(2u*(grp+2u)))&3u)<<4); int si1=(int)(chk*8+l/16+2u*(grp+2u)); uint j1=chk*128+(grp+2u)*32+l;\n\
+            acc+=x[(unsigned long)s*I+(unsigned long)bi*256+j1]*(d*(float)sc[si1]*(float)(qr1-32));\n\
+        }\n\
+    }\n\
+    threadgroup float wb[NW]; float total=reduce_all(acc,wb,tid); if(tid==0) y[(unsigned long)s*O+o]=total;\n\
+}\n\
+/* trivial kernel for dispatch-overhead probe */\n\
+kernel void noop_k(device float* y [[buffer(0)]],uint gid [[thread_position_in_threadgroup]]){ if(gid==0u) y[0]=0.0f; }\n\
+";
+
+// ---------------- timing ----------------
+static double g_tick2ns=0;
+static double now_s(void){ if(!g_tick2ns){ mach_timebase_info_data_t tb; mach_timebase_info(&tb); g_tick2ns=(double)tb.numer/(double)tb.denom; } return (double)mach_absolute_time()*g_tick2ns/1e9; }
+
+static id<MTLCommandBuffer> enc_matmul(id<MTLCommandQueue> q, id<MTLComputePipelineState> ps,
+        id<MTLBuffer> w, id<MTLBuffer> x, id<MTLBuffer> y, int I,int S,int O){
+    id<MTLCommandBuffer> cb=[q commandBuffer];
+    id<MTLComputeCommandEncoder> e=[cb computeCommandEncoder];
+    [e setComputePipelineState:ps];
+    [e setBuffer:w offset:0 atIndex:0]; [e setBuffer:x offset:0 atIndex:1]; [e setBuffer:y offset:0 atIndex:2];
+    int32_t cI=I,cS=S,cO=O; [e setBytes:&cI length:4 atIndex:3]; [e setBytes:&cS length:4 atIndex:4]; [e setBytes:&cO length:4 atIndex:5];
+    [e dispatchThreadgroups:MTLSizeMake((NSUInteger)O,(NSUInteger)S,1) threadsPerThreadgroup:MTLSizeMake(TPB,1,1)];
+    [e endEncoding]; return cb;
+}
+static double bench(id<MTLCommandQueue> q, id<MTLComputePipelineState> ps,
+        id<MTLBuffer> w,id<MTLBuffer> x,id<MTLBuffer> y,int I,int S,int O,int iters){
+    for(int i=0;i<5;i++){ @autoreleasepool{ id<MTLCommandBuffer> cb=enc_matmul(q,ps,w,x,y,I,S,O); [cb commit]; [cb waitUntilCompleted]; } }
+    double t0=now_s();
+    for(int i=0;i<iters;i++){ @autoreleasepool{ id<MTLCommandBuffer> cb=enc_matmul(q,ps,w,x,y,I,S,O); [cb commit]; [cb waitUntilCompleted]; } }
+    return (now_s()-t0)/(double)iters;
+}
+static double bench_noop(id<MTLCommandQueue> q, id<MTLComputePipelineState> ps, id<MTLBuffer> y, int iters){
+    for(int i=0;i<10;i++){ @autoreleasepool{ id<MTLCommandBuffer> cb=[q commandBuffer]; id<MTLComputeCommandEncoder> e=[cb computeCommandEncoder];
+        [e setComputePipelineState:ps]; [e setBuffer:y offset:0 atIndex:0];
+        [e dispatchThreadgroups:MTLSizeMake(1,1,1) threadsPerThreadgroup:MTLSizeMake(1,1,1)]; [e endEncoding]; [cb commit]; [cb waitUntilCompleted]; } }
+    double t0=now_s();
+    for(int i=0;i<iters;i++){ @autoreleasepool{ id<MTLCommandBuffer> cb=[q commandBuffer]; id<MTLComputeCommandEncoder> e=[cb computeCommandEncoder];
+        [e setComputePipelineState:ps]; [e setBuffer:y offset:0 atIndex:0];
+        [e dispatchThreadgroups:MTLSizeMake(1,1,1) threadsPerThreadgroup:MTLSizeMake(1,1,1)]; [e endEncoding]; [cb commit]; [cb waitUntilCompleted]; } }
+    return (now_s()-t0)/(double)iters;
+}
+
+static size_t row_bytes_for(int qtype,int I){
+    if(qtype==T_Q4K) return (size_t)(I/256)*144;
+    if(qtype==T_Q6K) return (size_t)(I/256)*210;
+    return 0;
+}
+
+int main(void){
+    @autoreleasepool {
+        id<MTLDevice> dev=MTLCreateSystemDefaultDevice();
+        if(!dev){ fprintf(stderr,"FAIL: no Metal device\n"); return 1; }
+        id<MTLCommandQueue> q=[dev newCommandQueue];
+        NSError* err=nil;
+        id<MTLLibrary> lib=[dev newLibraryWithSource:KS options:nil error:&err];
+        if(!lib){ fprintf(stderr,"FAIL compile: %s\n",[[err localizedDescription] UTF8String]); return 1; }
+        id<MTLComputePipelineState> ps_q4K =[dev newComputePipelineStateWithFunction:[lib newFunctionWithName:@"mm_q4_K"]  error:&err];
+        id<MTLComputePipelineState> ps_q6K =[dev newComputePipelineStateWithFunction:[lib newFunctionWithName:@"mm_q6_K"]  error:nil];
+        id<MTLComputePipelineState> ps_q6Kc=[dev newComputePipelineStateWithFunction:[lib newFunctionWithName:@"mm_q6_K_c"] error:nil];
+        id<MTLComputePipelineState> ps_noop=[dev newComputePipelineStateWithFunction:[lib newFunctionWithName:@"noop_k"]   error:nil];
+        if(!ps_q4K||!ps_q6K||!ps_q6Kc||!ps_noop){ fprintf(stderr,"FAIL: pipeline state\n"); return 1; }
+
+        NSLog(@"[bench] device: %@", dev.name);
+
+        // ---------- 1. correctness (small dims) ----------
+        printf("\n=== CORRECTNESS (GPU vs CPU; max abs diff) ===\n");
+        printf("%-12s type  I    O    S   maxdiff   verdict\n","kernel");
+        struct { const char* name; id<MTLComputePipelineState> ps; int qtype; } cks[]={
+            {"mm_q4_K",   ps_q4K,  T_Q4K}, {"mm_q6_K",   ps_q6K,  T_Q6K}, {"mm_q6_K_c", ps_q6Kc, T_Q6K},
+        };
+        int cdims[][3]={{256,32,1},{512,48,4}}; // (I,O,S)
+        float* tmp=(float*)malloc(4096*sizeof(float));
+        for(int c=0;c<3;c++){
+            for(int d=0;d<2;d++){
+                int I=cdims[d][0],O=cdims[d][1],S=cdims[d][2]; int qt=cks[c].qtype;
+                size_t rb=row_bytes_for(qt,I); size_t wb=O*rb, xb=(size_t)S*I*4, yb=(size_t)S*O*4;
+                uint8_t* wh=(uint8_t*)malloc(wb); gen_weights(wh,O,rb,qt);
+                float* xh=(float*)malloc(xb); for(size_t i=0;i<xb/4;i++) xh[i]=((float)(rand()%2001)-1000.0f)*1e-3f;
+                float* yref=(float*)malloc(yb);
+                for(int s=0;s<S;s++) for(int o=0;o<O;o++)
+                    yref[(size_t)s*O+o]=cpu_dot(wh+(size_t)o*rb, xh+(size_t)s*I, I, qt, tmp);
+                id<MTLBuffer> wbuf=[dev newBufferWithBytes:wh length:wb options:MTLResourceStorageModeShared];
+                id<MTLBuffer> xbuf=[dev newBufferWithBytes:xh length:xb options:MTLResourceStorageModeShared];
+                id<MTLBuffer> ybuf=[dev newBufferWithLength:yb options:MTLResourceStorageModeShared];
+                @autoreleasepool{ id<MTLCommandBuffer> cb=enc_matmul(q,cks[c].ps,wbuf,xbuf,ybuf,I,S,O); [cb commit]; [cb waitUntilCompleted]; }
+                const float* yg=(const float*)[ybuf contents]; float mx=0;
+                for(size_t i=0;i<yb/4;i++){ float df=fabsf(yg[i]-yref[i]); if(df>mx)mx=df; }
+                printf("%-12s Q%d_K  %-4d %-4d %-3d %.3e  %s\n", cks[c].name, qt==T_Q4K?4:6, I,O,S, mx, mx<1e-3f?"OK":"MISMATCH");
+                free(wh); free(xh); free(yref);
+            }
+        }
+        free(tmp);
+
+        // ---------- 2. dispatch overhead ----------
+        printf("\n=== DISPATCH OVERHEAD (noop kernel: encode+commit+waitUntilCompleted) ===\n");
+        id<MTLBuffer> y0=[dev newBufferWithLength:4 options:MTLResourceStorageModeShared];
+        double us=bench_noop(q,ps_noop,y0,2000)*1e6;
+        printf("   per dispatch: %.2f us   (decode does ~3 GPU dispatches/layer x 22 = ~66/token)\n", us);
+        printf("   => overhead floor @ 66 dispatches/token: %.2f ms/token  (~%.0f tok/s ceiling)\n", us*66/1000.0, 1000.0/(us*66/1000.0));
+
+        // ---------- 3. throughput ----------
+        printf("\n=== THROUGHPUT (ms/iter and effective weight bandwidth) ===\n");
+        printf("%-10s type  I     O      S    wMB    ms/iter   GB/s\n","kernel");
+        struct { const char* name; id<MTLComputePipelineState> ps; int qtype; } tks[]={
+            {"mm_q4_K",ps_q4K,T_Q4K},{"mm_q6_K",ps_q6K,T_Q6K},{"mm_q6_K_c",ps_q6Kc,T_Q6K},
+        };
+        int tdims[][3]={{2048,2048,1},{2048,5632,1},{5632,2048,1},{2048,32000,1},
+                        {2048,2048,32},{2048,5632,32},{2048,2048,128}};
+        for(int t=0;t<3;t++){
+            int qt=tks[t].qtype;
+            for(int d=0;d<7;d++){
+                int I=tdims[d][0],O=tdims[d][1],S=tdims[d][2];
+                size_t rb=row_bytes_for(qt,I); size_t wb=O*rb, xb=(size_t)S*I*4, yb=(size_t)S*O*4;
+                uint8_t* wh=(uint8_t*)malloc(wb); gen_weights(wh,O,rb,qt);
+                float* xh=(float*)malloc(xb); for(size_t i=0;i<xb/4;i++) xh[i]=((float)(rand()%2001)-1000.0f)*1e-3f;
+                id<MTLBuffer> wbuf=[dev newBufferWithBytesNoCopy:wh length:((wb+4095)&~(size_t)4095)
+                                options:MTLResourceStorageModeShared deallocator:^(void* p,NSUInteger l){(void)p;(void)l;}];
+                if(!wbuf) wbuf=[dev newBufferWithBytes:wh length:wb options:MTLResourceStorageModeShared];
+                id<MTLBuffer> xbuf=[dev newBufferWithBytes:xh length:xb options:MTLResourceStorageModeShared];
+                id<MTLBuffer> ybuf=[dev newBufferWithLength:yb options:MTLResourceStorageModeShared];
+                int iters = (S>=128)?30 : (S>=32?100:300);
+                double sec=bench(q,tks[t].ps,wbuf,xbuf,ybuf,I,S,O,iters);
+                double wmb=(double)wb/1e6, gbs=(double)wb/sec/1e9;
+                printf("%-10s Q%d_K  %-5d %-6d %-3d  %5.1f  %.4f   %6.1f\n", tks[t].name, qt==T_Q4K?4:6, I,O,S, wmb, sec*1e3, gbs);
+                free(wh); free(xh);
+            }
+        }
+        printf("\nApple M2 Pro ~200 GB/s unified-memory bandwidth is the roof for decode (S=1).\n");
+        return 0;
+    }
+}

--- a/picolm/probes/metal_matmul_bench.mm
+++ b/picolm/probes/metal_matmul_bench.mm
@@ -294,7 +294,7 @@ int main(void){
         };
         int cdims[][3]={{256,32,1},{512,48,4}}; // (I,O,S)
         float* tmp=(float*)malloc(4096*sizeof(float));
-        for(int c=0;c<3;c++){
+        for(int c=0;c<(int)(sizeof(cks)/sizeof(cks[0]));c++){
             for(int d=0;d<2;d++){
                 int I=cdims[d][0],O=cdims[d][1],S=cdims[d][2]; int qt=cks[c].qtype;
                 size_t rb=row_bytes_for(qt,I); size_t wb=O*rb, xb=(size_t)S*I*4, yb=(size_t)S*O*4;
@@ -324,7 +324,7 @@ int main(void){
 
         // ---------- 3. throughput ----------
         printf("\n=== THROUGHPUT (ms/iter and effective weight bandwidth) ===\n");
-        printf("%-10s type  I     O      S    wMB    ms/iter   GB/s\n","kernel");
+        printf("%-10s type  I     O      S    wMB   ms/iter    GB/s   kGB/s\n","kernel");
         struct { const char* name; id<MTLComputePipelineState> ps; int qtype; int mo; } tks[]={
             {"mm_q4_K",   ps_q4K,   T_Q4K, 1},
             {"mm_q6_K_c", ps_q6Kc,  T_Q6K, 1},
@@ -333,7 +333,7 @@ int main(void){
         };
         int tdims[][3]={{2048,2048,1},{2048,5632,1},{5632,2048,1},{2048,32000,1},
                         {2048,2048,32},{2048,5632,32},{2048,2048,128}};
-        for(int t=0;t<3;t++){
+        for(int t=0;t<(int)(sizeof(tks)/sizeof(tks[0]));t++){
             int qt=tks[t].qtype;
             for(int d=0;d<7;d++){
                 int I=tdims[d][0],O=tdims[d][1],S=tdims[d][2];
@@ -348,7 +348,9 @@ int main(void){
                 int iters = (S>=128)?30 : (S>=32?100:300);
                 double sec=bench(q,tks[t].ps,wbuf,xbuf,ybuf,I,S,O,tks[t].mo,iters);
                 double wmb=(double)wb/1e6, gbs=(double)wb/sec/1e9;
-                printf("%-10s Q%d_K  %-5d %-6d %-3d  %5.1f  %.4f   %6.1f\n", tks[t].name, qt==T_Q4K?4:6, I,O,S, wmb, sec*1e3, gbs);
+                double ksec=sec-us*1e-6; if(ksec<1e-9) ksec=1e-9;     /* subtract dispatch overhead */
+                double kgbs=(double)wb/ksec/1e9;                       /* true kernel bandwidth   */
+                printf("%-10s Q%d_K  %-5d %-6d %-3d  %5.1f  %.4f   %6.1f %6.1f\n", tks[t].name, qt==T_Q4K?4:6, I,O,S, wmb, sec*1e3, gbs, kgbs);
                 free(wh); free(xh);
             }
         }

--- a/picolm/probes/metal_matmul_bench.mm
+++ b/picolm/probes/metal_matmul_bench.mm
@@ -184,48 +184,48 @@ kernel void mm_q6_K_c(device const uint8_t* w [[buffer(0)]],device const float* 
     }\n\
     threadgroup float wb[NW]; float total=reduce_all(acc,wb,tid); if(tid==0) y[(unsigned long)s*O+o]=total;\n\
 }\n\
-/* ---- MULTI-OUTPUT decode GEMV (1 warp per output; no cross-warp reduce) ----
- * grid=(O/8,S,1), TG=256 (8 warps). warp w computes output o=gp.x*8+w over ALL
- * blocks; simd_sum within the warp only (no threadgroup barrier / shared mem).
- * Cuts the per-output reduction and packs 8 outputs per threadgroup -> better
- * effective bandwidth, esp. on small-I rows (lm_head). */
-kernel void mm_q4_K_mo(device const uint8_t* w [[buffer(0)]],device const float* x [[buffer(1)]],device float* y [[buffer(2)]],
-   constant int& I [[buffer(3)]],constant int& S [[buffer(4)]],constant int& O [[buffer(5)]],
-   uint tid [[thread_index_in_threadgroup]],uint2 gp [[threadgroup_position_in_grid]]){
-    int s=(int)gp.y; int o=(int)gp.x*8+(int)(tid>>5); if(o>=O) return;
-    int nblocks=I/256; device const uint8_t* row=w+(unsigned long)o*(unsigned long)(nblocks*144);
-    uint lane=tid&31,g=lane/8,within=(lane&7)*4; float acc=0.0f;
-    for(int bi=0;bi<nblocks;bi++){ device const uint8_t* blk=row+(unsigned long)(bi*144);
-        float d=f16tof32((uint16_t)blk[0]|((uint16_t)blk[1]<<8)); float dmin=f16tof32((uint16_t)blk[2]|((uint16_t)blk[3]<<8));
-        device const uint8_t* scales=blk+4; device const uint8_t* qs=blk+16;
-        float d_lo,m_lo,d_hi,m_hi; k4_unpack(scales,2*(int)g,d_lo,m_lo,d,dmin); k4_unpack(scales,2*(int)g+1,d_hi,m_hi,d,dmin);
-        uint qw=*(device const uint*)(qs+lane*4); uint base=(uint)(bi*256)+g*64+within;
-        for(int k=0;k<4;k++){ uint bv=(qw>>(k*8))&0xFF; float lo=(float)(bv&0xF),hi=(float)(bv>>4);
-            acc+=x[(unsigned long)s*I+base+k]*(d_lo*lo-m_lo); acc+=x[(unsigned long)s*I+base+k+32]*(d_hi*hi-m_hi); }
-    }
-    float total=simd_sum(acc); if(lane==0) y[(unsigned long)s*O+o]=total;
-}
-kernel void mm_q6_K_mo(device const uint8_t* w [[buffer(0)]],device const float* x [[buffer(1)]],device float* y [[buffer(2)]],
-   constant int& I [[buffer(3)]],constant int& S [[buffer(4)]],constant int& O [[buffer(5)]],
-   uint tid [[thread_index_in_threadgroup]],uint2 gp [[threadgroup_position_in_grid]]){
-    int s=(int)gp.y; int o=(int)gp.x*8+(int)(tid>>5); if(o>=O) return;
-    int nblocks=I/256; device const uint8_t* row=w+(unsigned long)o*(unsigned long)(nblocks*210);
-    uint lane=tid&31; float acc=0.0f;
-    for(int bi=0;bi<nblocks;bi++){ device const uint8_t* blk=row+(unsigned long)(bi*210);
-        float d=f16tof32((uint16_t)blk[208]|((uint16_t)blk[209]<<8));
-        device const uint8_t* ql=blk; device const uint8_t* qh=blk+128; device const int8_t* sc=(device const int8_t*)(blk+192);
-        for(int k=0;k<4;k++){ uint b=(uint)(k*32)+lane; uint chk=b>>6,grp=(b&63)>>5,l=b&31;
-            uint qlb=ql[b]; uint qhb=qh[chk*32+l];
-            int qr0=(int)(qlb&0xF)|(int)(((qhb>>(2u*grp))&3u)<<4); int si0=(int)(chk*8+l/16+2u*grp); uint j0=chk*128+grp*32+l;
-            acc+=x[(unsigned long)s*I+(unsigned long)bi*256+j0]*(d*(float)sc[si0]*(float)(qr0-32));
-            int qr1=(int)(qlb>>4)|(int)(((qhb>>(2u*(grp+2u)))&3u)<<4); int si1=(int)(chk*8+l/16+2u*(grp+2u)); uint j1=chk*128+(grp+2u)*32+l;
-            acc+=x[(unsigned long)s*I+(unsigned long)bi*256+j1]*(d*(float)sc[si1]*(float)(qr1-32));
-        }
-    }
-    float total=simd_sum(acc); if(lane==0) y[(unsigned long)s*O+o]=total;
-}
-/* trivial kernel for dispatch-overhead probe */
-kernel void noop_k(device float* y [[buffer(0)]],uint gid [[thread_position_in_threadgroup]]){ if(gid==0u) y[0]=0.0f; }
+/* ---- MULTI-OUTPUT decode GEMV (1 warp per output; no cross-warp reduce) ----\n\
+ * grid=(O/8,S,1), TG=256 (8 warps). warp w computes output o=gp.x*8+w over ALL\n\
+ * blocks; simd_sum within the warp only (no threadgroup barrier / shared mem).\n\
+ * Cuts the per-output reduction and packs 8 outputs per threadgroup -> better\n\
+ * effective bandwidth, esp. on small-I rows (lm_head). */\n\
+kernel void mm_q4_K_mo(device const uint8_t* w [[buffer(0)]],device const float* x [[buffer(1)]],device float* y [[buffer(2)]],\n\
+   constant int& I [[buffer(3)]],constant int& S [[buffer(4)]],constant int& O [[buffer(5)]],\n\
+   uint tid [[thread_index_in_threadgroup]],uint2 gp [[threadgroup_position_in_grid]]){\n\
+    int s=(int)gp.y; int o=(int)gp.x*8+(int)(tid>>5); if(o>=O) return;\n\
+    int nblocks=I/256; device const uint8_t* row=w+(unsigned long)o*(unsigned long)(nblocks*144);\n\
+    uint lane=tid&31,g=lane/8,within=(lane&7)*4; float acc=0.0f;\n\
+    for(int bi=0;bi<nblocks;bi++){ device const uint8_t* blk=row+(unsigned long)(bi*144);\n\
+        float d=f16tof32((uint16_t)blk[0]|((uint16_t)blk[1]<<8)); float dmin=f16tof32((uint16_t)blk[2]|((uint16_t)blk[3]<<8));\n\
+        device const uint8_t* scales=blk+4; device const uint8_t* qs=blk+16;\n\
+        float d_lo,m_lo,d_hi,m_hi; k4_unpack(scales,2*(int)g,d_lo,m_lo,d,dmin); k4_unpack(scales,2*(int)g+1,d_hi,m_hi,d,dmin);\n\
+        uint qw=*(device const uint*)(qs+lane*4); uint base=(uint)(bi*256)+g*64+within;\n\
+        for(int k=0;k<4;k++){ uint bv=(qw>>(k*8))&0xFF; float lo=(float)(bv&0xF),hi=(float)(bv>>4);\n\
+            acc+=x[(unsigned long)s*I+base+k]*(d_lo*lo-m_lo); acc+=x[(unsigned long)s*I+base+k+32]*(d_hi*hi-m_hi); }\n\
+    }\n\
+    float total=simd_sum(acc); if(lane==0) y[(unsigned long)s*O+o]=total;\n\
+}\n\
+kernel void mm_q6_K_mo(device const uint8_t* w [[buffer(0)]],device const float* x [[buffer(1)]],device float* y [[buffer(2)]],\n\
+   constant int& I [[buffer(3)]],constant int& S [[buffer(4)]],constant int& O [[buffer(5)]],\n\
+   uint tid [[thread_index_in_threadgroup]],uint2 gp [[threadgroup_position_in_grid]]){\n\
+    int s=(int)gp.y; int o=(int)gp.x*8+(int)(tid>>5); if(o>=O) return;\n\
+    int nblocks=I/256; device const uint8_t* row=w+(unsigned long)o*(unsigned long)(nblocks*210);\n\
+    uint lane=tid&31; float acc=0.0f;\n\
+    for(int bi=0;bi<nblocks;bi++){ device const uint8_t* blk=row+(unsigned long)(bi*210);\n\
+        float d=f16tof32((uint16_t)blk[208]|((uint16_t)blk[209]<<8));\n\
+        device const uint8_t* ql=blk; device const uint8_t* qh=blk+128; device const int8_t* sc=(device const int8_t*)(blk+192);\n\
+        for(int k=0;k<4;k++){ uint b=(uint)(k*32)+lane; uint chk=b>>6,grp=(b&63)>>5,l=b&31;\n\
+            uint qlb=ql[b]; uint qhb=qh[chk*32+l];\n\
+            int qr0=(int)(qlb&0xF)|(int)(((qhb>>(2u*grp))&3u)<<4); int si0=(int)(chk*8+l/16+2u*grp); uint j0=chk*128+grp*32+l;\n\
+            acc+=x[(unsigned long)s*I+(unsigned long)bi*256+j0]*(d*(float)sc[si0]*(float)(qr0-32));\n\
+            int qr1=(int)(qlb>>4)|(int)(((qhb>>(2u*(grp+2u)))&3u)<<4); int si1=(int)(chk*8+l/16+2u*(grp+2u)); uint j1=chk*128+(grp+2u)*32+l;\n\
+            acc+=x[(unsigned long)s*I+(unsigned long)bi*256+j1]*(d*(float)sc[si1]*(float)(qr1-32));\n\
+        }\n\
+    }\n\
+    float total=simd_sum(acc); if(lane==0) y[(unsigned long)s*O+o]=total;\n\
+}\n\
+/* trivial kernel for dispatch-overhead probe */\n\
+kernel void noop_k(device float* y [[buffer(0)]],uint gid [[thread_position_in_threadgroup]]){ if(gid==0u) y[0]=0.0f; }\n\
 ";
 
 // ---------------- timing ----------------

--- a/picolm/probes/metal_matmul_bench.mm
+++ b/picolm/probes/metal_matmul_bench.mm
@@ -184,8 +184,48 @@ kernel void mm_q6_K_c(device const uint8_t* w [[buffer(0)]],device const float* 
     }\n\
     threadgroup float wb[NW]; float total=reduce_all(acc,wb,tid); if(tid==0) y[(unsigned long)s*O+o]=total;\n\
 }\n\
-/* trivial kernel for dispatch-overhead probe */\n\
-kernel void noop_k(device float* y [[buffer(0)]],uint gid [[thread_position_in_threadgroup]]){ if(gid==0u) y[0]=0.0f; }\n\
+/* ---- MULTI-OUTPUT decode GEMV (1 warp per output; no cross-warp reduce) ----
+ * grid=(O/8,S,1), TG=256 (8 warps). warp w computes output o=gp.x*8+w over ALL
+ * blocks; simd_sum within the warp only (no threadgroup barrier / shared mem).
+ * Cuts the per-output reduction and packs 8 outputs per threadgroup -> better
+ * effective bandwidth, esp. on small-I rows (lm_head). */
+kernel void mm_q4_K_mo(device const uint8_t* w [[buffer(0)]],device const float* x [[buffer(1)]],device float* y [[buffer(2)]],
+   constant int& I [[buffer(3)]],constant int& S [[buffer(4)]],constant int& O [[buffer(5)]],
+   uint tid [[thread_index_in_threadgroup]],uint2 gp [[threadgroup_position_in_grid]]){
+    int s=(int)gp.y; int o=(int)gp.x*8+(int)(tid>>5); if(o>=O) return;
+    int nblocks=I/256; device const uint8_t* row=w+(unsigned long)o*(unsigned long)(nblocks*144);
+    uint lane=tid&31,g=lane/8,within=(lane&7)*4; float acc=0.0f;
+    for(int bi=0;bi<nblocks;bi++){ device const uint8_t* blk=row+(unsigned long)(bi*144);
+        float d=f16tof32((uint16_t)blk[0]|((uint16_t)blk[1]<<8)); float dmin=f16tof32((uint16_t)blk[2]|((uint16_t)blk[3]<<8));
+        device const uint8_t* scales=blk+4; device const uint8_t* qs=blk+16;
+        float d_lo,m_lo,d_hi,m_hi; k4_unpack(scales,2*(int)g,d_lo,m_lo,d,dmin); k4_unpack(scales,2*(int)g+1,d_hi,m_hi,d,dmin);
+        uint qw=*(device const uint*)(qs+lane*4); uint base=(uint)(bi*256)+g*64+within;
+        for(int k=0;k<4;k++){ uint bv=(qw>>(k*8))&0xFF; float lo=(float)(bv&0xF),hi=(float)(bv>>4);
+            acc+=x[(unsigned long)s*I+base+k]*(d_lo*lo-m_lo); acc+=x[(unsigned long)s*I+base+k+32]*(d_hi*hi-m_hi); }
+    }
+    float total=simd_sum(acc); if(lane==0) y[(unsigned long)s*O+o]=total;
+}
+kernel void mm_q6_K_mo(device const uint8_t* w [[buffer(0)]],device const float* x [[buffer(1)]],device float* y [[buffer(2)]],
+   constant int& I [[buffer(3)]],constant int& S [[buffer(4)]],constant int& O [[buffer(5)]],
+   uint tid [[thread_index_in_threadgroup]],uint2 gp [[threadgroup_position_in_grid]]){
+    int s=(int)gp.y; int o=(int)gp.x*8+(int)(tid>>5); if(o>=O) return;
+    int nblocks=I/256; device const uint8_t* row=w+(unsigned long)o*(unsigned long)(nblocks*210);
+    uint lane=tid&31; float acc=0.0f;
+    for(int bi=0;bi<nblocks;bi++){ device const uint8_t* blk=row+(unsigned long)(bi*210);
+        float d=f16tof32((uint16_t)blk[208]|((uint16_t)blk[209]<<8));
+        device const uint8_t* ql=blk; device const uint8_t* qh=blk+128; device const int8_t* sc=(device const int8_t*)(blk+192);
+        for(int k=0;k<4;k++){ uint b=(uint)(k*32)+lane; uint chk=b>>6,grp=(b&63)>>5,l=b&31;
+            uint qlb=ql[b]; uint qhb=qh[chk*32+l];
+            int qr0=(int)(qlb&0xF)|(int)(((qhb>>(2u*grp))&3u)<<4); int si0=(int)(chk*8+l/16+2u*grp); uint j0=chk*128+grp*32+l;
+            acc+=x[(unsigned long)s*I+(unsigned long)bi*256+j0]*(d*(float)sc[si0]*(float)(qr0-32));
+            int qr1=(int)(qlb>>4)|(int)(((qhb>>(2u*(grp+2u)))&3u)<<4); int si1=(int)(chk*8+l/16+2u*(grp+2u)); uint j1=chk*128+(grp+2u)*32+l;
+            acc+=x[(unsigned long)s*I+(unsigned long)bi*256+j1]*(d*(float)sc[si1]*(float)(qr1-32));
+        }
+    }
+    float total=simd_sum(acc); if(lane==0) y[(unsigned long)s*O+o]=total;
+}
+/* trivial kernel for dispatch-overhead probe */
+kernel void noop_k(device float* y [[buffer(0)]],uint gid [[thread_position_in_threadgroup]]){ if(gid==0u) y[0]=0.0f; }
 ";
 
 // ---------------- timing ----------------
@@ -193,20 +233,21 @@ static double g_tick2ns=0;
 static double now_s(void){ if(!g_tick2ns){ mach_timebase_info_data_t tb; mach_timebase_info(&tb); g_tick2ns=(double)tb.numer/(double)tb.denom; } return (double)mach_absolute_time()*g_tick2ns/1e9; }
 
 static id<MTLCommandBuffer> enc_matmul(id<MTLCommandQueue> q, id<MTLComputePipelineState> ps,
-        id<MTLBuffer> w, id<MTLBuffer> x, id<MTLBuffer> y, int I,int S,int O){
+        id<MTLBuffer> w, id<MTLBuffer> x, id<MTLBuffer> y, int I,int S,int O,int mo){
+    NSUInteger gx = (mo>1) ? (NSUInteger)((O+mo-1)/mo) : (NSUInteger)O;
     id<MTLCommandBuffer> cb=[q commandBuffer];
     id<MTLComputeCommandEncoder> e=[cb computeCommandEncoder];
     [e setComputePipelineState:ps];
     [e setBuffer:w offset:0 atIndex:0]; [e setBuffer:x offset:0 atIndex:1]; [e setBuffer:y offset:0 atIndex:2];
     int32_t cI=I,cS=S,cO=O; [e setBytes:&cI length:4 atIndex:3]; [e setBytes:&cS length:4 atIndex:4]; [e setBytes:&cO length:4 atIndex:5];
-    [e dispatchThreadgroups:MTLSizeMake((NSUInteger)O,(NSUInteger)S,1) threadsPerThreadgroup:MTLSizeMake(TPB,1,1)];
+    [e dispatchThreadgroups:MTLSizeMake(gx,(NSUInteger)S,1) threadsPerThreadgroup:MTLSizeMake(TPB,1,1)];
     [e endEncoding]; return cb;
 }
 static double bench(id<MTLCommandQueue> q, id<MTLComputePipelineState> ps,
-        id<MTLBuffer> w,id<MTLBuffer> x,id<MTLBuffer> y,int I,int S,int O,int iters){
-    for(int i=0;i<5;i++){ @autoreleasepool{ id<MTLCommandBuffer> cb=enc_matmul(q,ps,w,x,y,I,S,O); [cb commit]; [cb waitUntilCompleted]; } }
+        id<MTLBuffer> w,id<MTLBuffer> x,id<MTLBuffer> y,int I,int S,int O,int mo,int iters){
+    for(int i=0;i<5;i++){ @autoreleasepool{ id<MTLCommandBuffer> cb=enc_matmul(q,ps,w,x,y,I,S,O,mo); [cb commit]; [cb waitUntilCompleted]; } }
     double t0=now_s();
-    for(int i=0;i<iters;i++){ @autoreleasepool{ id<MTLCommandBuffer> cb=enc_matmul(q,ps,w,x,y,I,S,O); [cb commit]; [cb waitUntilCompleted]; } }
+    for(int i=0;i<iters;i++){ @autoreleasepool{ id<MTLCommandBuffer> cb=enc_matmul(q,ps,w,x,y,I,S,O,mo); [cb commit]; [cb waitUntilCompleted]; } }
     return (now_s()-t0)/(double)iters;
 }
 static double bench_noop(id<MTLCommandQueue> q, id<MTLComputePipelineState> ps, id<MTLBuffer> y, int iters){
@@ -234,19 +275,22 @@ int main(void){
         NSError* err=nil;
         id<MTLLibrary> lib=[dev newLibraryWithSource:KS options:nil error:&err];
         if(!lib){ fprintf(stderr,"FAIL compile: %s\n",[[err localizedDescription] UTF8String]); return 1; }
-        id<MTLComputePipelineState> ps_q4K =[dev newComputePipelineStateWithFunction:[lib newFunctionWithName:@"mm_q4_K"]  error:&err];
-        id<MTLComputePipelineState> ps_q6K =[dev newComputePipelineStateWithFunction:[lib newFunctionWithName:@"mm_q6_K"]  error:nil];
-        id<MTLComputePipelineState> ps_q6Kc=[dev newComputePipelineStateWithFunction:[lib newFunctionWithName:@"mm_q6_K_c"] error:nil];
-        id<MTLComputePipelineState> ps_noop=[dev newComputePipelineStateWithFunction:[lib newFunctionWithName:@"noop_k"]   error:nil];
-        if(!ps_q4K||!ps_q6K||!ps_q6Kc||!ps_noop){ fprintf(stderr,"FAIL: pipeline state\n"); return 1; }
+        id<MTLComputePipelineState> ps_q4K  =[dev newComputePipelineStateWithFunction:[lib newFunctionWithName:@"mm_q4_K"]    error:&err];
+        id<MTLComputePipelineState> ps_q6K  =[dev newComputePipelineStateWithFunction:[lib newFunctionWithName:@"mm_q6_K"]    error:nil];
+        id<MTLComputePipelineState> ps_q6Kc =[dev newComputePipelineStateWithFunction:[lib newFunctionWithName:@"mm_q6_K_c"]  error:nil];
+        id<MTLComputePipelineState> ps_q4Kmo=[dev newComputePipelineStateWithFunction:[lib newFunctionWithName:@"mm_q4_K_mo"] error:nil];
+        id<MTLComputePipelineState> ps_q6Kmo=[dev newComputePipelineStateWithFunction:[lib newFunctionWithName:@"mm_q6_K_mo"] error:nil];
+        id<MTLComputePipelineState> ps_noop =[dev newComputePipelineStateWithFunction:[lib newFunctionWithName:@"noop_k"]     error:nil];
+        if(!ps_q4K||!ps_q6K||!ps_q6Kc||!ps_q4Kmo||!ps_q6Kmo||!ps_noop){ fprintf(stderr,"FAIL: pipeline state\n"); return 1; }
 
         NSLog(@"[bench] device: %@", dev.name);
 
         // ---------- 1. correctness (small dims) ----------
         printf("\n=== CORRECTNESS (GPU vs CPU; max abs diff) ===\n");
         printf("%-12s type  I    O    S   maxdiff   verdict\n","kernel");
-        struct { const char* name; id<MTLComputePipelineState> ps; int qtype; } cks[]={
-            {"mm_q4_K",   ps_q4K,  T_Q4K}, {"mm_q6_K",   ps_q6K,  T_Q6K}, {"mm_q6_K_c", ps_q6Kc, T_Q6K},
+        struct { const char* name; id<MTLComputePipelineState> ps; int qtype; int mo; } cks[]={
+            {"mm_q4_K",   ps_q4K,   T_Q4K, 1}, {"mm_q6_K",   ps_q6K,   T_Q6K, 1}, {"mm_q6_K_c", ps_q6Kc,  T_Q6K, 1},
+            {"mm_q4_K_mo",ps_q4Kmo, T_Q4K, 8}, {"mm_q6_K_mo",ps_q6Kmo, T_Q6K, 8},
         };
         int cdims[][3]={{256,32,1},{512,48,4}}; // (I,O,S)
         float* tmp=(float*)malloc(4096*sizeof(float));
@@ -262,7 +306,7 @@ int main(void){
                 id<MTLBuffer> wbuf=[dev newBufferWithBytes:wh length:wb options:MTLResourceStorageModeShared];
                 id<MTLBuffer> xbuf=[dev newBufferWithBytes:xh length:xb options:MTLResourceStorageModeShared];
                 id<MTLBuffer> ybuf=[dev newBufferWithLength:yb options:MTLResourceStorageModeShared];
-                @autoreleasepool{ id<MTLCommandBuffer> cb=enc_matmul(q,cks[c].ps,wbuf,xbuf,ybuf,I,S,O); [cb commit]; [cb waitUntilCompleted]; }
+                @autoreleasepool{ id<MTLCommandBuffer> cb=enc_matmul(q,cks[c].ps,wbuf,xbuf,ybuf,I,S,O,cks[c].mo); [cb commit]; [cb waitUntilCompleted]; }
                 const float* yg=(const float*)[ybuf contents]; float mx=0;
                 for(size_t i=0;i<yb/4;i++){ float df=fabsf(yg[i]-yref[i]); if(df>mx)mx=df; }
                 printf("%-12s Q%d_K  %-4d %-4d %-3d %.3e  %s\n", cks[c].name, qt==T_Q4K?4:6, I,O,S, mx, mx<1e-3f?"OK":"MISMATCH");
@@ -281,8 +325,11 @@ int main(void){
         // ---------- 3. throughput ----------
         printf("\n=== THROUGHPUT (ms/iter and effective weight bandwidth) ===\n");
         printf("%-10s type  I     O      S    wMB    ms/iter   GB/s\n","kernel");
-        struct { const char* name; id<MTLComputePipelineState> ps; int qtype; } tks[]={
-            {"mm_q4_K",ps_q4K,T_Q4K},{"mm_q6_K",ps_q6K,T_Q6K},{"mm_q6_K_c",ps_q6Kc,T_Q6K},
+        struct { const char* name; id<MTLComputePipelineState> ps; int qtype; int mo; } tks[]={
+            {"mm_q4_K",   ps_q4K,   T_Q4K, 1},
+            {"mm_q6_K_c", ps_q6Kc,  T_Q6K, 1},
+            {"mm_q4_K_mo",ps_q4Kmo, T_Q4K, 8},
+            {"mm_q6_K_mo",ps_q6Kmo, T_Q6K, 8},
         };
         int tdims[][3]={{2048,2048,1},{2048,5632,1},{5632,2048,1},{2048,32000,1},
                         {2048,2048,32},{2048,5632,32},{2048,2048,128}};
@@ -299,7 +346,7 @@ int main(void){
                 id<MTLBuffer> xbuf=[dev newBufferWithBytes:xh length:xb options:MTLResourceStorageModeShared];
                 id<MTLBuffer> ybuf=[dev newBufferWithLength:yb options:MTLResourceStorageModeShared];
                 int iters = (S>=128)?30 : (S>=32?100:300);
-                double sec=bench(q,tks[t].ps,wbuf,xbuf,ybuf,I,S,O,iters);
+                double sec=bench(q,tks[t].ps,wbuf,xbuf,ybuf,I,S,O,tks[t].mo,iters);
                 double wmb=(double)wb/1e6, gbs=(double)wb/sec/1e9;
                 printf("%-10s Q%d_K  %-5d %-6d %-3d  %5.1f  %.4f   %6.1f\n", tks[t].name, qt==T_Q4K?4:6, I,O,S, wmb, sec*1e3, gbs);
                 free(wh); free(xh);

--- a/picolm/probes/metal_model_bench.sh
+++ b/picolm/probes/metal_model_bench.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# probes/metal_model_bench.sh
+#
+# End-to-end timing of the PicoLM Metal backend on real GGUF models.
+# Runs ./picolm on each model, parses prefill/generation tok/s, and prints a
+# table. Use it to measure optimization gains (run before/after with the same
+# models and compare).
+#
+# Run from picolm/picolm (where the `picolm` binary lives). Build first with:
+#     make metal
+# then:
+#     make metal-model-bench            # GPU only
+#     make metal-model-bench CPU=1      # GPU + CPU baseline (CPU can be slow!)
+#     LABEL=after make metal-model-bench # tag the run
+#
+# Override models / prompt / length with env vars or args:
+#     MODELS="../../a.gguf ../../b.gguf" make metal-model-bench
+#     ./probes/metal_model_bench.sh /abs/path/model.gguf
+set -u
+
+BIN="${BIN:-./picolm}"
+PROMPT="${PROMPT:-The capital of France is}"
+N="${N:-60}"
+LABEL="${LABEL:-gpu}"
+DO_CPU="${CPU:-0}"
+MODELS_DIR="${MODELS_DIR:-../..}"
+
+# --- resolve model list: args > $MODELS > autodiscover in $MODELS_DIR ---
+if [ "$#" -gt 0 ]; then
+    MODELS="$*"
+else
+    MODELS="${MODELS:-}"
+    if [ -z "$MODELS" ]; then
+        discovered=""
+        for pat in "*tinyllama*Q4_K*" "*ThinkingCap-Qwen3.6-27B-Q4_K_M*" "*Qwen3*-27B*Q4_K*"; do
+            for f in "$MODELS_DIR"/$pat; do
+                [ -f "$f" ] && discovered="$discovered $f"
+            done
+        done
+        MODELS="$(echo $discovered | tr ' ' '\n' | awk '!seen[$0]++' | tr '\n' ' ')"
+    fi
+fi
+
+# --- checks ---
+if [ ! -x "$BIN" ]; then
+    echo "ERROR: binary '$BIN' not found. Build it first:  make metal" >&2
+    exit 1
+fi
+if [ -z "$MODELS" ]; then
+    echo "ERROR: no models found in '$MODELS_DIR'. Pass paths as args:" >&2
+    echo "       ./probes/metal_model_bench.sh /path/to/model.gguf" >&2
+    exit 1
+fi
+
+echo "metal-model-bench  bin=$BIN  label=$LABEL  prompt=\"$PROMPT\"  n=$N  cpu=$DO_CPU"
+printf "%-46s %-5s %12s %12s %10s   %s\n" "model" "mode" "prefill(t/s)" "gen(t/s)" "total(s)" "sample output"
+printf '%0.s-' $(seq 1 118); echo
+
+run_one() {
+    local model="$1" mode="$2"
+    local gpu_flag=""
+    [ "$mode" = "gpu" ] && gpu_flag="PICOLM_GPU=1"
+    local out
+    out=$(env $gpu_flag "$BIN" "$model" -p "$PROMPT" -n "$N" -t 0 2>&1)
+    # parse: "Prefill: 6 tokens in 0.31s (19.1 tok/s)"  /  "Generation: ..."  /  "Total: 4.66s"
+    local pft=$(echo "$out" | grep -i 'Prefill:'    | sed -n 's/.*(\([0-9.]*\) tok\/s).*/\1/p')
+    local gnt=$(echo "$out" | grep -i 'Generation:' | sed -n 's/.*(\([0-9.]*\) tok\/s).*/\1/p')
+    local tot=$(echo "$out" | grep -i 'Total:'      | sed -n 's/Total: *\([0-9.]*\)s.*/\1/p')
+    local sample=$(echo "$out" | sed -n 's/^OUTPUT: *//p' | tr '\n' ' ' | cut -c1-30)
+    [ -z "$pft" ] && pft="-"
+    [ -z "$gnt" ] && gnt="-"
+    [ -z "$tot" ] && tot="-"
+    [ -z "$sample" ] && sample="(no OUTPUT line)"
+    local base; base=$(basename "$model")
+    printf "%-46s %-5s %12s %12s %10s   %s\n" "$base" "$mode" "$pft" "$gnt" "$tot" "$sample"
+}
+
+for m in $MODELS; do
+    if [ ! -f "$m" ]; then echo "skip (missing): $m" >&2; continue; fi
+    run_one "$m" "gpu"
+    if [ "$DO_CPU" = "1" ]; then run_one "$m" "cpu"; fi
+done
+echo

--- a/picolm/probes/metal_model_bench.sh
+++ b/picolm/probes/metal_model_bench.sh
@@ -32,11 +32,13 @@ else
     MODELS="${MODELS:-}"
     if [ -z "$MODELS" ]; then
         discovered=""
-        for pat in "*tinyllama*Q4_K*" "*ThinkingCap-Qwen3.6-27B-Q4_K_M*" "*Qwen3*-27B*Q4_K*"; do
+        shopt -s nocaseglob
+        for pat in "*tinyllama*q4*" "*thinkingcap*qwen*27b*q4*" "*qwen3*27b*q4*" "*qwen*-27b*q4*"; do
             for f in "$MODELS_DIR"/$pat; do
                 [ -f "$f" ] && discovered="$discovered $f"
             done
         done
+        shopt -u nocaseglob
         MODELS="$(echo $discovered | tr ' ' '\n' | awk '!seen[$0]++' | tr '\n' ' ')"
     fi
 fi

--- a/picolm/probes/metal_reduction_probe.mm
+++ b/picolm/probes/metal_reduction_probe.mm
@@ -1,0 +1,207 @@
+// probes/metal_reduction_probe.mm
+//
+// Self-contained smoke test for the PicoLM Metal backend's kernel mechanism
+// (raw Metal framework, no MLX-C/CMake). Run with: make metal-probe-run
+//
+// It exercises, in one small GEMV, everything the backend kernels depend on:
+//   1. compiling a Metal Shading Language kernel from a source string at runtime
+//   2. reading raw GGUF bytes via `device const uint8_t*`
+//   3. dequantizing Q4_0 blocks on the fly (fp16 scale via as_type<half>)
+//   4. cooperating across a threadgroup with shared memory + tree reduction
+//   5. shared-storage (unified-memory) buffers for host<->device data
+//
+// Computes y[O] = W[O,I] @ x[I] on the GPU and diffs against a CPU reference;
+// prints PASS/FAIL. Catches toolchain/MSL regressions independently of any
+// model file.
+//
+// Computes y[O] = W[O,I] @ x[I], W in Q4_0 (18B per 32 values),
+// O=4, I=64, TPB=32 (each thread handles 2 blocks, strided). Compares to a
+// CPU reference; prints PASS/FAIL.
+//
+// BUILD:  make metal-probe       (or see Makefile)
+// RUN:    ./probes/metal_reduction_probe
+
+#include <metal/Metal.h>
+#include <Foundation/Foundation.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <math.h>
+#include <string.h>
+
+#define O 4
+#define I 64
+#define TPB 32
+#define BLOCKS_PER_ROW (I / 32)         // 2
+#define Q4_0_BLOCK_BYTES 18             // uint16 d + uint8 qs[16]
+#define ROW_BYTES (BLOCKS_PER_ROW * Q4_0_BLOCK_BYTES)
+
+// ---- host-side fp16 <-> fp32 (matches PicoLM's quant.c software path) ----
+static float fp16_to_fp32_sw(uint16_t h) {
+    uint32_t sign = (h >> 15) & 0x1;
+    uint32_t exp  = (h >> 10) & 0x1f;
+    uint32_t mant =  h        & 0x3ff;
+    uint32_t f;
+    if (exp == 0) {
+        if (mant == 0) { f = sign << 31; }
+        else { exp = 1; while (!(mant & 0x400)) { mant <<= 1; exp--; }
+              mant &= 0x3ff;
+              f = (sign << 31) | ((exp + 127 - 15) << 23) | (mant << 13); }
+    } else { f = (sign << 31) | ((exp + 127 - 15) << 23) | (mant << 13); }
+    float out; memcpy(&out, &f, 4); return out;
+}
+static uint16_t fp32_to_fp16_sw(float f) {
+    uint32_t x; memcpy(&x, &f, 4);
+    uint32_t sign = (x >> 16) & 0x8000;
+    int32_t  exp  = (int32_t)((x >> 23) & 0xff) - 127 + 15;
+    uint32_t mant = x & 0x7fffff;
+    if (exp <= 0) {
+        if (exp < -10) return sign;
+        mant |= 0x800000;
+        uint32_t sh = (uint32_t)(14 - exp);
+        uint32_t mo = mant >> sh;
+        if ((mant >> (sh - 1)) & 1) mo++;
+        return sign | mo;
+    } else if (exp >= 0x1f) { return sign | 0x7c00; }
+    uint32_t out = sign | (exp << 10) | (mant >> 13);
+    if ((mant >> 12) & 1) out++;
+    return out;
+}
+
+// ---- Metal Shading Language kernel (compiled at runtime from this string) ----
+//   buffer(0): w   device const uint8_t*  GGUF byte blob [O*ROW_BYTES]
+//   buffer(1): x   device const float*    activations [I]
+//   buffer(2): y   device float*          output [O]
+//   buffer(3): I   constant int           (via setBytes)
+//   buffer(4): TPB constant int           (via setBytes)
+static NSString* KERNEL_SRC = @"\
+#include <metal_stdlib>\n\
+using namespace metal;\n\
+kernel void gemv_q4_0(device const uint8_t* w [[buffer(0)]],\n\
+                      device const float*   x [[buffer(1)]],\n\
+                      device float*         y [[buffer(2)]],\n\
+                      constant int& I       [[buffer(3)]],\n\
+                      constant int& TPB     [[buffer(4)]],\n\
+                      uint tid [[thread_index_in_threadgroup]],\n\
+                      uint gp  [[threadgroup_position_in_grid]]) {\n\
+    int o = (int)gp;\n\
+    const int BLOCKS = I / 32;\n\
+    const device uint8_t* row = w + (unsigned long)o * (unsigned long)(BLOCKS * 18);\n\
+    float sum = 0.0f;\n\
+    for (int bi = (int)tid; bi < BLOCKS; bi += (int)TPB) {\n\
+        const device uint8_t* blk = row + (unsigned long)(bi * 18);\n\
+        uint16_t d_raw = (uint16_t)blk[0] | ((uint16_t)blk[1] << 8);\n\
+        float d = (float)as_type<half>(d_raw);\n\
+        for (int j = 0; j < 32; j++) {\n\
+            int nib = (blk[2 + (j >> 1)] >> ((j & 1) * 4)) & 0xF;\n\
+            sum += x[bi * 32 + j] * (float)(nib - 8) * d;\n\
+        }\n\
+    }\n\
+    threadgroup float shared[256];\n\
+    shared[tid] = sum;\n\
+    threadgroup_barrier(mem_flags::mem_threadgroup);\n\
+    for (int n = TPB >> 1; n > 0; n >>= 1) {\n\
+        if (tid < (uint)n) shared[tid] += shared[tid + n];\n\
+        threadgroup_barrier(mem_flags::mem_threadgroup);\n\
+    }\n\
+    if (tid == 0) y[o] = shared[0];\n\
+}\n";
+
+int main(void) {
+    @autoreleasepool {
+        // ---- 0. device ----
+        id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+        if (!device) { fprintf(stderr, "FAIL: no Metal device\n"); return 1; }
+        NSLog(@"[probe] device: %@", device.name);
+
+        // ---- 1. build host data ----
+        uint8_t w_host[O * ROW_BYTES];
+        for (int o = 0; o < O; o++) {
+            for (int bi = 0; bi < BLOCKS_PER_ROW; bi++) {
+                uint8_t *blk = w_host + o * ROW_BYTES + bi * Q4_0_BLOCK_BYTES;
+                float scale = 0.5f * (float)(bi + 1) + 0.1f * (float)o;
+                uint16_t d = fp32_to_fp16_sw(scale);
+                blk[0] = d & 0xFF; blk[1] = (d >> 8) & 0xFF;
+                for (int b = 0; b < 16; b++) {
+                    uint8_t lo = (uint8_t)((o * 7 + bi * 3 + b * 5) & 0xF);
+                    uint8_t hi = (uint8_t)((o * 11 + bi * 13 + b * 2) & 0xF);
+                    blk[2 + b] = lo | (hi << 4);
+                }
+            }
+        }
+        float x_host[I];
+        for (int i = 0; i < I; i++) x_host[i] = (float)(i - I / 2) * 0.01f;
+
+        // ---- 2. CPU reference ----
+        float y_ref[O];
+        for (int o = 0; o < O; o++) {
+            double acc = 0.0;
+            for (int bi = 0; bi < BLOCKS_PER_ROW; bi++) {
+                const uint8_t *blk = w_host + o * ROW_BYTES + bi * Q4_0_BLOCK_BYTES;
+                uint16_t d_raw = blk[0] | ((uint16_t)blk[1] << 8);
+                float d = fp16_to_fp32_sw(d_raw);
+                for (int j = 0; j < 32; j++) {
+                    int nib = (blk[2 + (j >> 1)] >> ((j & 1) * 4)) & 0xF;
+                    acc += x_host[bi * 32 + j] * (double)(nib - 8) * (double)d;
+                }
+            }
+            y_ref[o] = (float)acc;
+        }
+
+        // ---- 3. compile kernel ----
+        NSError* err = nil;
+        id<MTLLibrary> lib = [device newLibraryWithSource:KERNEL_SRC
+                                                  options:nil
+                                                    error:&err];
+        if (!lib) { fprintf(stderr, "FAIL: compile library: %s\n",
+                            [[err localizedDescription] UTF8String]); return 1; }
+        id<MTLFunction> func = [lib newFunctionWithName:@"gemv_q4_0"];
+        id<MTLComputePipelineState> ps =
+            [device newComputePipelineStateWithFunction:func error:&err];
+        if (!ps) { fprintf(stderr, "FAIL: pipeline: %s\n",
+                           [[err localizedDescription] UTF8String]); return 1; }
+
+        // ---- 4. buffers (shared storage = unified memory, CPU+GPU visible) ----
+        id<MTLBuffer> wbuf = [device newBufferWithBytes:w_host
+                                                 length:sizeof(w_host)
+                                                options:MTLResourceStorageModeShared];
+        id<MTLBuffer> xbuf = [device newBufferWithBytes:x_host
+                                                 length:sizeof(x_host)
+                                                options:MTLResourceStorageModeShared];
+        id<MTLBuffer> ybuf = [device newBufferWithLength:O * sizeof(float)
+                                                options:MTLResourceStorageModeShared];
+        if (!wbuf || !xbuf || !ybuf) { fprintf(stderr, "FAIL: buffer alloc\n"); return 1; }
+
+        // ---- 5. encode + dispatch ----
+        int32_t I_const = I, TPB_const = TPB;
+        id<MTLCommandQueue> queue = [device newCommandQueue];
+        id<MTLCommandBuffer> cmd = [queue commandBuffer];
+        id<MTLComputeCommandEncoder> enc = [cmd computeCommandEncoder];
+        [enc setComputePipelineState:ps];
+        [enc setBuffer:wbuf offset:0 atIndex:0];
+        [enc setBuffer:xbuf offset:0 atIndex:1];
+        [enc setBuffer:ybuf offset:0 atIndex:2];
+        [enc setBytes:&I_const   length:sizeof(I_const)   atIndex:3];
+        [enc setBytes:&TPB_const length:sizeof(TPB_const) atIndex:4];
+        [enc dispatchThreadgroups:MTLSizeMake(O, 1, 1)
+            threadsPerThreadgroup:MTLSizeMake(TPB, 1, 1)];
+        [enc endEncoding];
+        [cmd commit];
+        [cmd waitUntilCompleted];
+
+        // ---- 6. read back + compare ----
+        const float *y_gpu = (const float *)[ybuf contents];
+        int pass = 1; float max_abs = 0.0f;
+        printf("[probe] O=%d I=%d TPB=%d  per-output results:\n", O, I, TPB);
+        for (int o = 0; o < O; o++) {
+            float diff = fabsf(y_gpu[o] - y_ref[o]);
+            if (diff > max_abs) max_abs = diff;
+            int ok = diff < 1e-4f;
+            printf("   y[%d]  gpu=%+.6f  cpu=%+.6f  diff=%.2e  %s\n",
+                   o, y_gpu[o], y_ref[o], diff, ok ? "ok" : "MISMATCH");
+            if (!ok) pass = 0;
+        }
+        printf("[probe] max abs diff = %.3e  ->  %s\n", max_abs, pass ? "PASS" : "FAIL");
+        return pass ? 0 : 2;
+    }
+}


### PR DESCRIPTION
Wire the validated mm_q4_K_mo / mm_q6_K_mo kernels (1 warp per output, no
cross-warp barrier, simd_sum only) into the backend as the Q4_K/Q6_K matmul
path. ps_for_qtype now routes Q4_K/Q6_K to the _mo pipeline states, and
launch_matmul dispatches grid_x=(O+7)/8 for those types (others unchanged).

Validated correct vs CPU reference by probes/metal_matmul_bench (maxdiff
~1e-5, identical order to the single-output kernel) and faster on
medium/large matmuls in the kGB/s column, e.g.:
  Q4_K (I=5632,O=2048): 52.7 -> 75.4 kGB/s
  Q6_K (I=5632,O=2048): 118.6 -> 149.6 kGB/s
  Q6_K lmhead (O=32000): 72.4 -> 84.4 kGB/s
Small matmuls are dispatch-bound so unaffected; the win targets large-O rows
(FFN gate/up, lm_head) where it matters most for big models.

The old single-output mm_q4_K / mm_q6_K kernels are retained (still built)
as reference/fallback; only the routing changed. End-to-end impact pending a
model-bench run (expect ~neutral TinyLlama, which is dispatch-bound at
23.8 tok/s; 27B is kernel-bound and should improve).