### PR TITLE
SSM prefill GPU crash from wrong struct-array indexing (27B Qwen3.6)

### DIFF
--- a/picolm/backend_metal.mm
+++ b/picolm/backend_metal.mm
@@ -456,8 +456,19 @@ static int g_ndev = 0;
 
 // Grow-only scratch buffers (mirror CUDA's reserve()). Shared storage mode =
 // unified memory: CPU writes x, GPU reads x & writes y, CPU reads y.
+//
+// These stay hazard-TRACKED (the default): picolm_gpu_expert_mlp issues 4
+// separate compute encoders in ONE command buffer with cross-encoder
+// read-after-write deps on g_gate/g_up (gate matmul -> silu_mul -> down
+// matmul). Default tracking is what serializes those across encoders; making
+// them Untracked would race. The per-call waitUntilCompleted below does not
+// help with intra-command-buffer ordering.
 static id<MTLBuffer> g_x = nil, g_y = nil, g_gate = nil, g_up = nil;
 static size_t g_xcap = 0, g_ycap = 0, g_gatecap = 0, g_upcap = 0;
+// Cached CPU mappings of the scratch buffers (stable for a buffer's lifetime;
+// refreshed only on reallocation inside reserve_buf). Saves a
+// -[MTLBuffer contents] message send on every dispatch.
+static void *g_xptr = NULL, *g_yptr = NULL, *g_gateptr = NULL, *g_upptr = NULL;
 
 static id<MTLComputePipelineState> ps_for_qtype(gguf_type_t q) {
     switch (q) {
@@ -475,11 +486,22 @@ static id<MTLComputePipelineState> ps_for_qtype(gguf_type_t q) {
 // Grow-only: only (re)allocates when current capacity is too small.
 // Parameter qualified __strong so we can pass &g_x (a strong global); the
 // default (__autoreleasing*) would reject address-of-strong-global under ARC.
-static id<MTLBuffer> reserve_buf(__strong id<MTLBuffer> *buf, size_t *cap, size_t bytes) {
+//
+// `options` tunes the CPU cache policy for shared storage:
+//   - WriteCombined for CPU->GPU upload buffers (g_x): the CPU write streams
+//     straight to unified memory without evicting hot host data, and is never
+//     read back on the CPU. This is the hot path (every matmul memcpy()s x in).
+//   - DefaultCache  for GPU->CPU download buffers (g_y): CPU reads them back.
+// `ptr_out` (may be NULL) receives the stable -contents pointer, so callers
+// skip the message send per dispatch.
+static id<MTLBuffer> reserve_buf(__strong id<MTLBuffer> *buf, size_t *cap,
+                                 void **ptr_out, size_t bytes,
+                                 MTLResourceOptions options) {
     if (*buf && *cap >= bytes) return *buf;
-    *buf = [g_device newBufferWithLength:bytes options:MTLResourceStorageModeShared];
-    if (!*buf) { *cap = 0; return nil; }
+    *buf = [g_device newBufferWithLength:bytes options:options];
+    if (!*buf) { *cap = 0; if (ptr_out) *ptr_out = NULL; return nil; }
     *cap = bytes;
+    if (ptr_out) *ptr_out = [*buf contents];
     return *buf;
 }
 
@@ -550,6 +572,7 @@ int picolm_gpu_init(const int *devices, int count) {
 void picolm_gpu_shutdown(void) {
     g_x = g_y = g_gate = g_up = nil;
     g_xcap = g_ycap = g_gatecap = g_upcap = 0;
+    g_xptr = g_yptr = g_gateptr = g_upptr = NULL;
     g_ps_f32 = g_ps_f16 = g_ps_q4_0 = g_ps_q8_0 = g_ps_q4_K = g_ps_q5_K = g_ps_q6_K = g_ps_silu = nil;
     g_library = nil; g_queue = nil; g_device = nil;
     g_ndev = 0;
@@ -608,10 +631,16 @@ int picolm_gpu_tensor_upload(void **tensor,
     uintptr_t base_addr = addr & ~(uintptr_t)(page - 1);   /* round down to page */
     size_t pad_lo = (size_t)(addr - base_addr);
     size_t aligned_len = (total + pad_lo + page - 1) & ~(page - 1);  /* round up */
+    /* Untracked: weights are read-only on the GPU and never written by host or
+     * device after upload, so there is no read-after-write hazard to track.
+     * Removing per-resource hazard tracking lowers dispatch-encoding overhead
+     * for every matmul that binds a weight buffer (the common case). Ordering
+     * vs the CPU is provided by the per-call waitUntilCompleted full barrier. */
     buf = [g_device newBufferWithBytesNoCopy:(void *)base_addr
                                       length:aligned_len
                                       options:MTLResourceStorageModeShared |
-                                               MTLResourceCPUCacheModeDefaultCache
+                                               MTLResourceCPUCacheModeDefaultCache |
+                                               MTLResourceHazardTrackingModeUntracked
                                       deallocator:^(void *ptr, NSUInteger len) {
                                           /* mmap'd memory is owned by the model; nothing to free. */
                                           (void)ptr; (void)len;
@@ -620,8 +649,11 @@ int picolm_gpu_tensor_upload(void **tensor,
         zero_copy = 1;
         buf_offset = pad_lo;
     } else {
-        /* Fallback: one-time copy into a shared-storage buffer (offset 0). */
-        buf = [g_device newBufferWithBytes:weights length:total options:MTLResourceStorageModeShared];
+        /* Fallback: one-time copy into a shared-storage buffer (offset 0).
+         * Untracked here too (see above): read-only on the GPU. */
+        buf = [g_device newBufferWithBytes:weights length:total
+                                   options:MTLResourceStorageModeShared |
+                                            MTLResourceHazardTrackingModeUntracked];
         buf_offset = 0;
     }
     if (!buf) {
@@ -694,17 +726,26 @@ int picolm_gpu_matmul(picolm_gpu_tensor_t *t, float *y, const float *x, int S, i
     int I = t->I, O = t->O;
     size_t xb = (size_t)S * I * sizeof(float);
     size_t yb = (size_t)S * O * sizeof(float);
-    if (!reserve_buf(&g_x, &g_xcap, xb)) return 0;
-    if (!reserve_buf(&g_y, &g_ycap, yb)) return 0;
+    /* g_x is CPU-written/GPU-read -> WriteCombined (streaming write, no cache
+     * pollution). g_y is GPU-written/CPU-read -> DefaultCache. */
+    if (!reserve_buf(&g_x, &g_xcap, &g_xptr, xb,
+                     MTLResourceStorageModeShared | MTLResourceCPUCacheModeWriteCombined)) return 0;
+    if (!reserve_buf(&g_y, &g_ycap, &g_yptr, yb,
+                     MTLResourceStorageModeShared | MTLResourceCPUCacheModeDefaultCache)) return 0;
 
-    memcpy([g_x contents], x, xb);
+    memcpy(g_xptr, x, xb);
 
-    id<MTLCommandBuffer> cmd = [g_queue commandBuffer];
+    /* Unretained command buffer: skips per-resource retain/release bookkeeping
+     * for every bound buffer + pipeline state. Safe because every resource
+     * bound here is a static global (scratch buffers, pipeline states) or a
+     * model-resident weight tensor that outlives this command buffer. The
+     * function holds the command buffer until waitUntilCompleted anyway. */
+    id<MTLCommandBuffer> cmd = [g_queue commandBufferWithUnretainedReferences];
     if (!launch_matmul(t, g_x, g_y, S, cmd)) { return 0; }
     [cmd commit];
     [cmd waitUntilCompleted];
 
-    memcpy(y, [g_y contents], yb);
+    memcpy(y, g_yptr, yb);
     return 1;
 }
 
@@ -718,14 +759,23 @@ int picolm_gpu_expert_mlp(picolm_gpu_tensor_t *gate, picolm_gpu_tensor_t *up,
     int D = gate->I, I = gate->O;
     size_t xb = (size_t)S * D * sizeof(float);
     size_t ib = (size_t)S * I * sizeof(float);
-    if (!reserve_buf(&g_x,    &g_xcap,    xb)) return 0;
-    if (!reserve_buf(&g_y,    &g_ycap,    xb)) return 0;
-    if (!reserve_buf(&g_gate, &g_gatecap, ib)) return 0;
-    if (!reserve_buf(&g_up,   &g_upcap,   ib)) return 0;
+    /* g_x is the only CPU->GPU upload here (WriteCombined). g_y is read back on
+     * the CPU. g_gate/g_up are pure GPU scratch (written and re-read inside the
+     * command buffer), so their CPU cache mode is irrelevant; DefaultCache. */
+    if (!reserve_buf(&g_x,    &g_xcap,    &g_xptr,    xb,
+                     MTLResourceStorageModeShared | MTLResourceCPUCacheModeWriteCombined)) return 0;
+    if (!reserve_buf(&g_y,    &g_ycap,    &g_yptr,    xb,
+                     MTLResourceStorageModeShared | MTLResourceCPUCacheModeDefaultCache)) return 0;
+    if (!reserve_buf(&g_gate, &g_gatecap, &g_gateptr, ib,
+                     MTLResourceStorageModeShared | MTLResourceCPUCacheModeDefaultCache)) return 0;
+    if (!reserve_buf(&g_up,   &g_upcap,   &g_upptr,   ib,
+                     MTLResourceStorageModeShared | MTLResourceCPUCacheModeDefaultCache)) return 0;
 
-    memcpy([g_x contents], x, xb);
+    memcpy(g_xptr, x, xb);
 
-    id<MTLCommandBuffer> cmd = [g_queue commandBuffer];
+    /* Unretained command buffer: see picolm_gpu_matmul (every bound buffer
+     * outlives this command buffer). */
+    id<MTLCommandBuffer> cmd = [g_queue commandBufferWithUnretainedReferences];
     /* gate = W_gate @ x ; up = W_up @ x */
     if (!launch_matmul(gate, g_x, g_gate, S, cmd)) return 0;
     if (!launch_matmul(up,   g_x, g_up,   S, cmd)) return 0;
@@ -747,7 +797,7 @@ int picolm_gpu_expert_mlp(picolm_gpu_tensor_t *gate, picolm_gpu_tensor_t *up,
     [cmd commit];
     [cmd waitUntilCompleted];
 
-    memcpy(y, [g_y contents], xb);
+    memcpy(y, g_yptr, xb);
     return 1;
 }
 

--- a/picolm/model.c
+++ b/picolm/model.c
@@ -5083,16 +5083,21 @@ static void ssm_prefill_layer(model_t *m, run_state_t *s,
     /* 2. Batched QKV projection (read from ssm_xb with stride dim) */
     tensor_set_repacked(m->repack_used[ri] ? m->repack_buffers[ri] : NULL);
 #ifdef PICOLM_GPU
-    if (gpu_lw && gpu_lw[l]) {
-        gpu_layer_weights_t *gl = (gpu_layer_weights_t *)gpu_lw[l];
+    /* gpu_lw is gpu_layer_weights_t[] (an array of STRUCTS, ~80B each), passed
+     * as void**. Index with struct stride, NOT pointer stride -- the old
+     * `gpu_lw[l]` read a field value (a heap handle) as a struct pointer and
+     * crashed on gl->attn_qkv. m->gpu is zeroed in model_load, so any tensor
+     * not uploaded for this layer is NULL and matmul_batch falls back to CPU. */
+    if (gpu_lw) {
+        gpu_layer_weights_t *gl = &((gpu_layer_weights_t *)gpu_lw)[l];
         tensor_set_gpu_tensor((picolm_gpu_tensor_t *)gl->attn_qkv, m->gpu.device);
     }
 #endif
     matmul_batch(qkv_batch, ssm_xb, n_tokens, lw->attn_qkv, dim, conv_dim, lw->type_attn_qkv);
     tensor_set_repacked(NULL);
 #ifdef PICOLM_GPU
-    if (gpu_lw && gpu_lw[l]) {
-        gpu_layer_weights_t *gl = (gpu_layer_weights_t *)gpu_lw[l];
+    if (gpu_lw) {
+        gpu_layer_weights_t *gl = &((gpu_layer_weights_t *)gpu_lw)[l];
         tensor_set_gpu_tensor((picolm_gpu_tensor_t *)gl->attn_gate_ssm, m->gpu.device);
     }
 #endif
@@ -5102,7 +5107,7 @@ static void ssm_prefill_layer(model_t *m, run_state_t *s,
     matmul_batch(z_batch, ssm_xb, n_tokens, lw->attn_gate_ssm, dim, value_dim, lw->type_attn_gate_ssm);
     tensor_set_repacked(NULL);
 #ifdef PICOLM_GPU
-    if (gpu_lw[l]) tensor_set_gpu_tensor(NULL, 0);
+    if (gpu_lw) tensor_set_gpu_tensor(NULL, 0);
 #endif
     if (do_remap) {
         for (bi = 0; bi < n_tokens; bi++) {
@@ -5326,8 +5331,8 @@ static void ssm_prefill_layer(model_t *m, run_state_t *s,
     } else {
         tensor_set_repacked(m->repack_used[ri+5] ? m->repack_buffers[ri+5] : NULL);
 #ifdef PICOLM_GPU
-        if (gpu_lw[l]) {
-            gpu_layer_weights_t *gl = (gpu_layer_weights_t *)gpu_lw[l];
+        if (gpu_lw) {
+            gpu_layer_weights_t *gl = &((gpu_layer_weights_t *)gpu_lw)[l];
             tensor_set_gpu_tensor((picolm_gpu_tensor_t *)gl->ssm_out, m->gpu.device);
         }
 #endif
@@ -5339,7 +5344,7 @@ static void ssm_prefill_layer(model_t *m, run_state_t *s,
         free(ssm_out_buf);
         tensor_set_repacked(NULL);
 #ifdef PICOLM_GPU
-        if (gpu_lw[l]) tensor_set_gpu_tensor(NULL, 0);
+        if (gpu_lw) tensor_set_gpu_tensor(NULL, 0);
 #endif
     }
 


### PR DESCRIPTION
ssm_prefill_layer received m->gpu.layers (a gpu_layer_weights_t[] array of
~80B structs) cast to void**, then indexed it as gpu_lw[l] -- which strides
by sizeof(void*) (8B) instead of sizeof(gpu_layer_weights_t). For l>0 that
read a tensor-handle *value* (a heap pointer) and reinterpreted it as a
gpu_layer_weights_t*, so the subsequent gl->attn_qkv dereference faulted
(SIGSEGV at a garbage address like 0x44000000000e). It only triggered on
SSM-hybrid models (Qwen3.5/3.6) during batched prefill: standard attention
models never call ssm_prefill_layer, and the SSM decode path (ssm_forward)
already indexes correctly via the per-layer &m->gpu.layers[l] pointer it
receives.

Fix: index the struct array by struct stride -- &((gpu_layer_weights_t*)gpu_lw)[l]
(matching ssm_forward) -- and guard on `gpu_lw` (the array pointer) instead
of the misread gpu_lw[l] value. m->gpu is zeroed in model_load, so any
tensor not uploaded for a layer is NULL and matmul_batch falls back to CPU.
No behaviour change for non-SSM models or non-GPU builds.

Root-caused from the macOS crash report: picolm_gpu_matmul +80, ESR "byte
read Translation fault" at far=t+12 (the t->I load), with t a garbage handle.